### PR TITLE
GH-153: [feature] Create resend verification email endpoint

### DIFF
--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/client/KeycloakApiClient.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/client/KeycloakApiClient.java
@@ -372,7 +372,6 @@ public class KeycloakApiClient {
                 });
     }
 
-
     /**
      * Retrieves an access token using client credentials.
      * Caches the token and reuses it until it expires.
@@ -460,5 +459,4 @@ public class KeycloakApiClient {
                     return Mono.error(new KeycloakCommunicationException(statusCode, combinedError));
                 });
     }
-
 }

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/controller/auth/AuthController.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/controller/auth/AuthController.java
@@ -47,12 +47,12 @@ public class AuthController {
         return authService.refreshToken(tokenRequest);
     }
 
-    @PutMapping("/resend-verification-email")
+    @PutMapping("/send-verification-email")
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "resend verification email",
             description = "random description"
     )
-    public void resendVerificationEmail(@RequestBody Map<String, Object> payload) {
+    public void sendVerificationEmail(@RequestBody Map<String, Object> payload) {
         authService.sendVerificationEmail(payload.get("email").toString());
     }
 }

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/controller/auth/AuthController.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/controller/auth/AuthController.java
@@ -13,6 +13,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Map;
+
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
@@ -43,6 +45,15 @@ public class AuthController {
             description = "Generates a new access token using the provided refresh token.")
     public TokenResponse refreshToken(@RequestBody RefreshTokenRequest tokenRequest) {
         return authService.refreshToken(tokenRequest);
+    }
+
+    @PutMapping("/resend-verification-email")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "resend verification email",
+            description = "random description"
+    )
+    public void resendVerificationEmail(@RequestBody Map<String, Object> payload) {
+        authService.sendVerificationEmail(payload.get("email").toString());
     }
 }
 

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/controller/auth/AuthController.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/controller/auth/AuthController.java
@@ -49,8 +49,8 @@ public class AuthController {
 
     @PutMapping("/send-verification-email")
     @ResponseStatus(HttpStatus.OK)
-    @Operation(summary = "resend verification email",
-            description = "random description"
+    @Operation(summary = "send verification email",
+            description = "Sends a verification email to the specified user. This email contains a link or token that the user must use to confirm their email address and complete the registration."
     )
     public void sendVerificationEmail(@RequestBody Map<String, Object> payload) {
         authService.sendVerificationEmail(payload.get("email").toString());

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/controller/auth/AuthController.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/controller/auth/AuthController.java
@@ -3,6 +3,7 @@ package app.sportahub.userservice.controller.auth;
 import app.sportahub.userservice.dto.request.auth.LoginRequest;
 import app.sportahub.userservice.dto.request.auth.RefreshTokenRequest;
 import app.sportahub.userservice.dto.request.auth.RegistrationRequest;
+import app.sportahub.userservice.dto.request.auth.SendVerificationEmailRequest;
 import app.sportahub.userservice.dto.response.auth.LoginResponse;
 import app.sportahub.userservice.dto.response.auth.TokenResponse;
 import app.sportahub.userservice.dto.response.user.UserResponse;
@@ -12,8 +13,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.Map;
 
 @RestController
 @RequestMapping("/auth")
@@ -52,8 +51,8 @@ public class AuthController {
     @Operation(summary = "send verification email",
             description = "Sends a verification email to the specified user. This email contains a link or token that the user must use to confirm their email address and complete the registration."
     )
-    public void sendVerificationEmail(@RequestBody Map<String, Object> payload) {
-        authService.sendVerificationEmail(payload.get("email").toString());
+    public void sendVerificationEmail(@RequestBody SendVerificationEmailRequest sendVerificationEmailRequest) {
+        authService.sendVerificationEmail(sendVerificationEmailRequest.email());
     }
 }
 

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/dto/request/auth/SendVerificationEmailRequest.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/dto/request/auth/SendVerificationEmailRequest.java
@@ -1,0 +1,8 @@
+package app.sportahub.userservice.dto.request.auth;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.constraints.Email;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record SendVerificationEmailRequest(@Email String email) {
+}

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/service/auth/AuthService.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/service/auth/AuthService.java
@@ -7,8 +7,6 @@ import app.sportahub.userservice.dto.response.auth.LoginResponse;
 import app.sportahub.userservice.dto.response.auth.TokenResponse;
 import app.sportahub.userservice.dto.response.user.UserResponse;
 
-import org.springframework.http.ResponseEntity;
-
 public interface AuthService {
 
     UserResponse registerUser(RegistrationRequest userRequest);

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/service/auth/AuthService.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/service/auth/AuthService.java
@@ -7,6 +7,8 @@ import app.sportahub.userservice.dto.response.auth.LoginResponse;
 import app.sportahub.userservice.dto.response.auth.TokenResponse;
 import app.sportahub.userservice.dto.response.user.UserResponse;
 
+import org.springframework.http.ResponseEntity;
+
 public interface AuthService {
 
     UserResponse registerUser(RegistrationRequest userRequest);
@@ -14,4 +16,6 @@ public interface AuthService {
     LoginResponse loginUser(LoginRequest loginRequest);
 
     TokenResponse refreshToken(RefreshTokenRequest tokenRequest);
+
+    void sendVerificationEmail(String userId);
 }

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/service/auth/AuthServiceImpl.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/service/auth/AuthServiceImpl.java
@@ -100,7 +100,6 @@ public class AuthServiceImpl implements AuthService {
     public void sendVerificationEmail(String email) {
         User user = userRepository.findUserByEmail(email).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
         JsonNode response = keycloakApiClient.sendVerificationEmail(user.getKeycloakId()).block();
-        log.info("AuthServiceImpl::sendVerificationEmail: {}", response);
-//        return ResponseEntity.ok().build();
+        log.info("AuthServiceImpl::sendVerificationEmail: verification email sent to {}", email);
     }
 }

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/service/auth/AuthServiceImpl.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/service/auth/AuthServiceImpl.java
@@ -15,7 +15,6 @@ import app.sportahub.userservice.exception.user.UsernameAlreadyExistsException;
 import app.sportahub.userservice.mapper.user.UserMapper;
 import app.sportahub.userservice.model.user.User;
 import app.sportahub.userservice.repository.UserRepository;
-import com.fasterxml.jackson.databind.JsonNode;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/service/auth/AuthServiceImpl.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/service/auth/AuthServiceImpl.java
@@ -9,6 +9,7 @@ import app.sportahub.userservice.dto.response.auth.LoginResponse;
 import app.sportahub.userservice.dto.response.auth.TokenResponse;
 import app.sportahub.userservice.dto.response.user.UserResponse;
 import app.sportahub.userservice.exception.user.InvalidCredentialsException;
+import app.sportahub.userservice.exception.user.UserDoesNotExistException;
 import app.sportahub.userservice.exception.user.UserEmailAlreadyExistsException;
 import app.sportahub.userservice.exception.user.UsernameAlreadyExistsException;
 import app.sportahub.userservice.mapper.user.UserMapper;
@@ -98,8 +99,8 @@ public class AuthServiceImpl implements AuthService {
 
     @Override
     public void sendVerificationEmail(String email) {
-        User user = userRepository.findUserByEmail(email).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
-        JsonNode response = keycloakApiClient.sendVerificationEmail(user.getKeycloakId()).block();
+        User user = userRepository.findUserByEmail(email).orElseThrow(() -> new UserDoesNotExistException(email));
+        keycloakApiClient.sendVerificationEmail(user.getKeycloakId()).block();
         log.info("AuthServiceImpl::sendVerificationEmail: verification email sent to {}", email);
     }
 }

--- a/Microservices/user-service/src/test/java/app/sportahub/userservice/controller/AuthControllerTest.java
+++ b/Microservices/user-service/src/test/java/app/sportahub/userservice/controller/AuthControllerTest.java
@@ -100,7 +100,4 @@ public class AuthControllerTest {
                 .andExpect(status().isInternalServerError())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.error").value("An unexpected error occurred: Unexpected error occurred")); // Updated to match actual response
     }
-
-
-
 }


### PR DESCRIPTION
# GH-153 - Create Resend Verification Email Endpoint

## Description
This PR adds functionality for sending verification email to users to confirm their email. It includes an endpoint, services to use the keycloakapiclient for email sending. Unit tests for the controller are provided to ensure functionality. 


## Changes
- **Controller**: Added endpoints to assign badges (`PUT /auth/send-verification-email`) 
- **Services**: Added logic for using the Keycloak client to send the verification email
- **Client**: Added method for calling the keycloak endpoint for sending verification email. 
- **Tests**: Added unit tests for the controller/endpoint method. 