### PR TITLE
GH-101: [feat] password reset endpoint

### DIFF
--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/config/auth/SecurityConfig.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/config/auth/SecurityConfig.java
@@ -22,6 +22,7 @@ public class SecurityConfig {
                                 "/auth/register",
                                 "/auth/login",
                                 "/auth/refresh",
+                                "/auth/reset-password",
                                 "/swagger-ui.html",
                                 "/api-docs",
                                 "/api-docs/**",

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/controller/auth/AuthController.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/controller/auth/AuthController.java
@@ -7,6 +7,7 @@ import app.sportahub.userservice.dto.response.user.UserResponse;
 import app.sportahub.userservice.service.auth.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -56,7 +57,7 @@ public class AuthController {
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "Send password reset email",
                description = "Sends an email to the specified user containing a temporary token to be used to update the password.")
-    public void sendPasswordResetEmail(@RequestBody SendPasswordResetEmailRequest sendPasswordResetEmail){
+    public void sendPasswordResetEmail(@Valid @RequestBody SendPasswordResetEmailRequest sendPasswordResetEmail){
         authService.sendPasswordResetEmail(sendPasswordResetEmail.email());
     }
 }

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/controller/auth/AuthController.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/controller/auth/AuthController.java
@@ -1,9 +1,6 @@
 package app.sportahub.userservice.controller.auth;
 
-import app.sportahub.userservice.dto.request.auth.LoginRequest;
-import app.sportahub.userservice.dto.request.auth.RefreshTokenRequest;
-import app.sportahub.userservice.dto.request.auth.RegistrationRequest;
-import app.sportahub.userservice.dto.request.auth.SendVerificationEmailRequest;
+import app.sportahub.userservice.dto.request.auth.*;
 import app.sportahub.userservice.dto.response.auth.LoginResponse;
 import app.sportahub.userservice.dto.response.auth.TokenResponse;
 import app.sportahub.userservice.dto.response.user.UserResponse;
@@ -53,6 +50,14 @@ public class AuthController {
     )
     public void sendVerificationEmail(@RequestBody SendVerificationEmailRequest sendVerificationEmailRequest) {
         authService.sendVerificationEmail(sendVerificationEmailRequest.email());
+    }
+
+    @PutMapping("/reset-password")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "Send password reset email",
+               description = "Sends an email to the specified user containing a temporary token to be used to update the password.")
+    public void sendPasswordResetEmail(@RequestBody SendPasswordResetEmailRequest sendPasswordResetEmail){
+        authService.sendPasswordResetEmail(sendPasswordResetEmail.email());
     }
 }
 

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/dto/request/auth/SendPasswordResetEmailRequest.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/dto/request/auth/SendPasswordResetEmailRequest.java
@@ -1,0 +1,8 @@
+package app.sportahub.userservice.dto.request.auth;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.constraints.Email;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record SendPasswordResetEmailRequest(@Email String email) {
+}

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/dto/request/auth/SendPasswordResetEmailRequest.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/dto/request/auth/SendPasswordResetEmailRequest.java
@@ -2,7 +2,8 @@ package app.sportahub.userservice.dto.request.auth;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotEmpty;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record SendPasswordResetEmailRequest(@Email String email) {
+public record SendPasswordResetEmailRequest(@Email @NotEmpty String email) {
 }

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/exception/GlobalExceptionHandler.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package app.sportahub.userservice.exception;
 import app.sportahub.userservice.exception.user.InvalidCredentialsException;
 import app.sportahub.userservice.exception.user.UserDoesNotExistException;
 import app.sportahub.userservice.exception.user.UserEmailAlreadyExistsException;
+import app.sportahub.userservice.exception.user.UserWithEmailDoesNotExistException;
 import app.sportahub.userservice.exception.user.badge.BadgeNotFoundException;
 import app.sportahub.userservice.exception.user.keycloak.KeycloakCommunicationException;
 import app.sportahub.userservice.exception.user.badge.UserAlreadyAssignedBadgeByThisGiverException;
@@ -37,6 +38,14 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(UserDoesNotExistException.class)
     public ResponseEntity<Map<String, Object>> handleUserDoesNotExistException(UserDoesNotExistException ex) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("error", ex.getReason());
+        response.put("status", ex.getStatusCode().value());
+        return ResponseEntity.status(ex.getStatusCode()).body(response);
+    }
+
+    @ExceptionHandler(UserWithEmailDoesNotExistException.class)
+    public ResponseEntity<Map<String, Object>> handleUserDoesNotExistException(UserWithEmailDoesNotExistException ex) {
         Map<String, Object> response = new HashMap<>();
         response.put("error", ex.getReason());
         response.put("status", ex.getStatusCode().value());

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/service/auth/AuthService.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/service/auth/AuthService.java
@@ -16,4 +16,6 @@ public interface AuthService {
     TokenResponse refreshToken(RefreshTokenRequest tokenRequest);
 
     void sendVerificationEmail(String userId);
+
+    void sendPasswordResetEmail(String email);
 }

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/service/auth/AuthServiceImpl.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/service/auth/AuthServiceImpl.java
@@ -111,7 +111,7 @@ public class AuthServiceImpl implements AuthService {
 
     @Override
     public void sendPasswordResetEmail(String email){
-        User user  = userRepository.findUserByEmail(email).orElseThrow(() -> new UserWithEmailDoesNotExistException(email));
+        User user  = userRepository.findUserByEmail(email.toLowerCase()).orElseThrow(() -> new UserWithEmailDoesNotExistException(email.toLowerCase()));
         keycloakApiClient.sendPasswordResetEmail(user.getKeycloakId()).block();
         log.info("AuthServiceImpl::sendPasswordResetEmail: password reset email sent to {}", email);
     }

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/service/auth/AuthServiceImpl.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/service/auth/AuthServiceImpl.java
@@ -8,10 +8,7 @@ import app.sportahub.userservice.dto.request.user.keycloak.KeycloakRequest;
 import app.sportahub.userservice.dto.response.auth.LoginResponse;
 import app.sportahub.userservice.dto.response.auth.TokenResponse;
 import app.sportahub.userservice.dto.response.user.UserResponse;
-import app.sportahub.userservice.exception.user.InvalidCredentialsException;
-import app.sportahub.userservice.exception.user.UserDoesNotExistException;
-import app.sportahub.userservice.exception.user.UserEmailAlreadyExistsException;
-import app.sportahub.userservice.exception.user.UsernameAlreadyExistsException;
+import app.sportahub.userservice.exception.user.*;
 import app.sportahub.userservice.mapper.user.UserMapper;
 import app.sportahub.userservice.model.user.User;
 import app.sportahub.userservice.repository.UserRepository;
@@ -110,5 +107,12 @@ public class AuthServiceImpl implements AuthService {
         User user = userRepository.findUserByEmail(email).orElseThrow(() -> new UserDoesNotExistException(email));
         keycloakApiClient.sendVerificationEmail(user.getKeycloakId()).block();
         log.info("AuthServiceImpl::sendVerificationEmail: verification email sent to {}", email);
+    }
+
+    @Override
+    public void sendPasswordResetEmail(String email){
+        User user  = userRepository.findUserByEmail(email).orElseThrow(() -> new UserWithEmailDoesNotExistException(email));
+        keycloakApiClient.sendPasswordResetEmail(user.getKeycloakId()).block();
+        log.info("AuthServiceImpl::sendPasswordResetEmail: password reset email sent to {}", email);
     }
 }


### PR DESCRIPTION
# Description
This pull request focuses on the creation of password-reset endpoint to allow a user to change their lost, forgotten, or compromised password. Modifications include sending password reset email with a time-limited link, updating user credentials, and conducting unit tests to make sure the endpoint functions as expected.

# File Changes & Additions
- `SendPasswordResetEmailRequest.java`: Cretae DTO to capture user email in http request
- `KeycloakApiClient.java` : Add new method to handle sending and receiving http response
- `AuthController.java`: Add new endpoint
- `GlobalExceptionHandler.java`: Add UserWithEmailDoesNotExist exception
- `AuthService.java`: Add sendPasswordResetEmail method
- `AuthServiceImpl.java`: Implement sendPasswordResetEmail method
- `AuthControllerTest.java`: Add new test cases for reset password endpoint

# Tests
- Successfully send request :heavy_check_mark: 
- Return Bad Request on non-registered email :heavy_check_mark: 
- Return Bad Request on empty email :heavy_check_mark: 
- Return Bad Request on invalid email format :heavy_check_mark: 
- Successfully send request for case-insensitive email :heavy_check_mark:  

