### PR TITLE
GH-190: Send friend request

### DIFF
--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/controller/user/UserController.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/controller/user/UserController.java
@@ -1,5 +1,6 @@
 package app.sportahub.userservice.controller.user;
 
+import app.sportahub.userservice.dto.response.user.FriendRequestResponse;
 import app.sportahub.userservice.dto.request.user.ProfileRequest;
 import app.sportahub.userservice.dto.request.user.UserRequest;
 import app.sportahub.userservice.dto.response.user.ProfileResponse;
@@ -65,5 +66,13 @@ public class UserController {
             description = "Retrieves all badges assigned to a user along with the count of each badge type.")
     public List<BadgeWithCountResponse> getUserBadges(@PathVariable String userId) {
         return userService.getUserBadges(userId);
+    }
+
+    @PostMapping("/{userId}/friends/requests")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "Send a friend request to a user",
+    description = "Allows a user to send a friend request to another user and returns the details of the friend request.")
+    public FriendRequestResponse sendFriendRequest(@PathVariable String userId, @RequestParam String receiverUsername) {
+        return userService.sendFriendRequest(userId, receiverUsername);
     }
 }

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/controller/user/UserController.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/controller/user/UserController.java
@@ -1,5 +1,6 @@
 package app.sportahub.userservice.controller.user;
 
+import app.sportahub.userservice.dto.request.user.FriendRequestRequest;
 import app.sportahub.userservice.dto.response.user.FriendRequestResponse;
 import app.sportahub.userservice.dto.request.user.ProfileRequest;
 import app.sportahub.userservice.dto.request.user.UserRequest;
@@ -72,7 +73,7 @@ public class UserController {
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "Send a friend request to a user",
     description = "Allows a user to send a friend request to another user and returns the details of the friend request.")
-    public FriendRequestResponse sendFriendRequest(@PathVariable String userId, @RequestParam String receiverUsername) {
-        return userService.sendFriendRequest(userId, receiverUsername);
+    public FriendRequestResponse sendFriendRequest(@PathVariable String userId, @RequestBody FriendRequestRequest friendRequestRequest) {
+        return userService.sendFriendRequest(userId, friendRequestRequest);
     }
 }

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/dto/request/user/FriendRequestRequest.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/dto/request/user/FriendRequestRequest.java
@@ -1,0 +1,4 @@
+package app.sportahub.userservice.dto.request.user;
+
+public record FriendRequestRequest() {
+}

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/dto/request/user/FriendRequestRequest.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/dto/request/user/FriendRequestRequest.java
@@ -1,4 +1,4 @@
 package app.sportahub.userservice.dto.request.user;
 
-public record FriendRequestRequest() {
+public record FriendRequestRequest(String receiverUsername) {
 }

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/dto/request/user/UserRequest.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/dto/request/user/UserRequest.java
@@ -1,9 +1,12 @@
 package app.sportahub.userservice.dto.request.user;
 
+import app.sportahub.userservice.model.user.Friend;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+
+import java.util.List;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record UserRequest(String keycloakId,
@@ -22,5 +25,8 @@ public record UserRequest(String keycloakId,
                           ProfileRequest profile,
 
                           @Nullable
-                          PreferencesRequest preferences) {
+                          PreferencesRequest preferences,
+
+                          @Nullable
+                          List<Friend> friendList) {
 }

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/dto/response/user/FriendRequestResponse.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/dto/response/user/FriendRequestResponse.java
@@ -1,0 +1,4 @@
+package app.sportahub.userservice.dto.response.user;
+
+public record FriendRequestResponse(String message, String status) {
+}

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/dto/response/user/UserResponse.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/dto/response/user/UserResponse.java
@@ -1,8 +1,11 @@
 package app.sportahub.userservice.dto.response.user;
 
+import app.sportahub.userservice.model.user.Friend;
 import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record UserResponse(String id, String keycloakId, String email, String username, ProfileResponse profile,
-                           PreferencesResponse preferences) {
+                           PreferencesResponse preferences, List<Friend> friendList) {
 }

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/enums/user/FriendRequestStatusEnum.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/enums/user/FriendRequestStatusEnum.java
@@ -1,0 +1,5 @@
+package app.sportahub.userservice.enums.user;
+
+public enum FriendRequestStatusEnum {
+    SENT, RECEIVED, ACCEPTED
+}

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/exception/GlobalExceptionHandler.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package app.sportahub.userservice.exception;
 import app.sportahub.userservice.exception.user.InvalidCredentialsException;
 import app.sportahub.userservice.exception.user.UserDoesNotExistException;
 import app.sportahub.userservice.exception.user.UserEmailAlreadyExistsException;
+import app.sportahub.userservice.exception.user.UserSentFriendRequestToSelfException;
 import app.sportahub.userservice.exception.user.UserWithEmailDoesNotExistException;
 import app.sportahub.userservice.exception.user.badge.BadgeNotFoundException;
 import app.sportahub.userservice.exception.user.keycloak.KeycloakCommunicationException;
@@ -90,5 +91,13 @@ public class GlobalExceptionHandler {
         response.put("error", ex.getMessage());
         response.put("status", HttpStatus.NOT_FOUND.value());
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+    }
+
+    @ExceptionHandler(UserSentFriendRequestToSelfException.class)
+    public ResponseEntity<Map<String, Object>> handleUserSentFriendRequestToSelfException(UserSentFriendRequestToSelfException ex) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("error", ex.getMessage());
+        response.put("status", HttpStatus.BAD_REQUEST.value());
+        return ResponseEntity.badRequest().body(response);
     }
 }

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/exception/UserAlreadyInFriendListException.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/exception/UserAlreadyInFriendListException.java
@@ -1,0 +1,15 @@
+package app.sportahub.userservice.exception;
+
+import app.sportahub.userservice.enums.user.FriendRequestStatusEnum;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+@ResponseStatus(code = HttpStatus.CONFLICT, reason = "User already in friend list.")
+public class UserAlreadyInFriendListException extends ResponseStatusException {
+
+    public UserAlreadyInFriendListException(String username, Enum<FriendRequestStatusEnum> friendRequestStatus) {
+        super(HttpStatus.CONFLICT, "User with username: " + username + " and status: "
+                + friendRequestStatus + " already in friend list.");
+    }
+}

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/exception/user/UserAlreadyInFriendListException.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/exception/user/UserAlreadyInFriendListException.java
@@ -1,4 +1,4 @@
-package app.sportahub.userservice.exception;
+package app.sportahub.userservice.exception.user;
 
 import app.sportahub.userservice.enums.user.FriendRequestStatusEnum;
 import org.springframework.http.HttpStatus;

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/exception/user/UserDoesNotExistException.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/exception/user/UserDoesNotExistException.java
@@ -4,7 +4,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.server.ResponseStatusException;
 
-@ResponseStatus(code = HttpStatus.CONFLICT, reason = "User does not exist.")
+@ResponseStatus(code = HttpStatus.NOT_FOUND, reason = "User does not exist.")
 public class UserDoesNotExistException extends ResponseStatusException {
 
     public UserDoesNotExistException(String identifier) {

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/exception/user/UserDoesNotExistException.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/exception/user/UserDoesNotExistException.java
@@ -7,7 +7,7 @@ import org.springframework.web.server.ResponseStatusException;
 @ResponseStatus(code = HttpStatus.CONFLICT, reason = "User does not exist.")
 public class UserDoesNotExistException extends ResponseStatusException {
 
-    public UserDoesNotExistException(String id) {
-        super(HttpStatus.NOT_FOUND, "User with id:" + id + "does not exist.");
+    public UserDoesNotExistException(String identifier) {
+        super(HttpStatus.NOT_FOUND, "User with identifier:" + identifier + "does not exist.");
     }
 }

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/exception/user/UserDoesNotExistException.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/exception/user/UserDoesNotExistException.java
@@ -8,6 +8,6 @@ import org.springframework.web.server.ResponseStatusException;
 public class UserDoesNotExistException extends ResponseStatusException {
 
     public UserDoesNotExistException(String identifier) {
-        super(HttpStatus.NOT_FOUND, "User with identifier:" + identifier + "does not exist.");
+        super(HttpStatus.NOT_FOUND, "User with identifier: " + identifier + " does not exist.");
     }
 }

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/exception/user/UserSentFriendRequestToSelfException.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/exception/user/UserSentFriendRequestToSelfException.java
@@ -1,0 +1,13 @@
+package app.sportahub.userservice.exception.user;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+@ResponseStatus(code = HttpStatus.CONFLICT, reason = "User sent friend request to self.")
+public class UserSentFriendRequestToSelfException extends ResponseStatusException {
+
+    public UserSentFriendRequestToSelfException() {
+        super(HttpStatus.CONFLICT, "Can't send friend request to self");
+    }
+}

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/exception/user/UserWithEmailDoesNotExistException.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/exception/user/UserWithEmailDoesNotExistException.java
@@ -1,0 +1,14 @@
+package app.sportahub.userservice.exception.user;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+@ResponseStatus(code = HttpStatus.NOT_FOUND, reason = "User with email does not exist.")
+public class UserWithEmailDoesNotExistException extends ResponseStatusException {
+
+    public UserWithEmailDoesNotExistException(String email)
+    {
+        super(HttpStatus.NOT_FOUND, "User with email: " + email + " does not exist.");
+    }
+}

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/model/user/Friend.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/model/user/Friend.java
@@ -17,5 +17,5 @@ public class Friend {
     private String username;
 
     @NotBlank(message = "Friend request status must be provided.")
-    private Enum<FriendRequestStatusEnum> friendRequestStatus;
+    private FriendRequestStatusEnum friendRequestStatus;
 }

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/model/user/Friend.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/model/user/Friend.java
@@ -1,0 +1,21 @@
+package app.sportahub.userservice.model.user;
+
+import app.sportahub.userservice.enums.user.FriendRequestStatusEnum;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder(setterPrefix = "with")
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class Friend {
+
+    @NotBlank(message = "Username of friend must be provided.")
+    private String username;
+
+    @NotBlank(message = "Friend request status must be provided.")
+    private Enum<FriendRequestStatusEnum> friendRequestStatus;
+}

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/model/user/User.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/model/user/User.java
@@ -7,6 +7,9 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @EqualsAndHashCode(callSuper = true)
 @SuperBuilder(toBuilder = true, setterPrefix = "with")
 @Document("user")
@@ -31,4 +34,7 @@ public class User extends BaseEntity {
 
     @Builder.Default
     private Preferences preferences = Preferences.builder().build();
+
+    @Builder.Default
+    private List<Friend> friendList = new ArrayList<>();
 }

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/service/user/UserService.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/service/user/UserService.java
@@ -1,5 +1,6 @@
 package app.sportahub.userservice.service.user;
 
+import app.sportahub.userservice.dto.request.user.FriendRequestRequest;
 import app.sportahub.userservice.dto.response.user.FriendRequestResponse;
 import app.sportahub.userservice.dto.request.user.ProfileRequest;
 import app.sportahub.userservice.dto.request.user.UserRequest;
@@ -23,5 +24,5 @@ public interface UserService {
 
     List<BadgeWithCountResponse> getUserBadges(String userId);
 
-    FriendRequestResponse sendFriendRequest(String userId, String receiverUsername);
+    FriendRequestResponse sendFriendRequest(String userId, FriendRequestRequest friendRequestRequest);
 }

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/service/user/UserService.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/service/user/UserService.java
@@ -1,11 +1,11 @@
 package app.sportahub.userservice.service.user;
 
+import app.sportahub.userservice.dto.response.user.FriendRequestResponse;
 import app.sportahub.userservice.dto.request.user.ProfileRequest;
 import app.sportahub.userservice.dto.request.user.UserRequest;
 import app.sportahub.userservice.dto.response.user.ProfileResponse;
 import app.sportahub.userservice.dto.response.user.UserResponse;
 import app.sportahub.userservice.dto.response.user.badge.BadgeWithCountResponse;
-import app.sportahub.userservice.model.user.User;
 
 import java.util.List;
 
@@ -22,4 +22,6 @@ public interface UserService {
     UserResponse assignBadge(String userId, String badgeId, String giverId);
 
     List<BadgeWithCountResponse> getUserBadges(String userId);
+
+    FriendRequestResponse sendFriendRequest(String userId, String receiverUsername);
 }

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/service/user/UserServiceImpl.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/service/user/UserServiceImpl.java
@@ -11,7 +11,7 @@ import app.sportahub.userservice.dto.response.user.UserResponse;
 import app.sportahub.userservice.dto.response.user.badge.BadgeResponse;
 import app.sportahub.userservice.dto.response.user.badge.BadgeWithCountResponse;
 import app.sportahub.userservice.enums.user.FriendRequestStatusEnum;
-import app.sportahub.userservice.exception.UserAlreadyInFriendListException;
+import app.sportahub.userservice.exception.user.UserAlreadyInFriendListException;
 import app.sportahub.userservice.exception.user.UserDoesNotExistException;
 import app.sportahub.userservice.exception.user.UserEmailAlreadyExistsException;
 import app.sportahub.userservice.exception.user.UserSentFriendRequestToSelfException;
@@ -151,7 +151,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public FriendRequestResponse sendFriendRequest(String userId, FriendRequestRequest friendRequestRequest) {
-        User userSender = userRepository.findById(userId)
+        User userSender = userRepository.findUserById(userId)
                 .orElseThrow(() -> new UserDoesNotExistException(userId));
         User userReceiver = userRepository.findUserByUsername(friendRequestRequest.receiverUsername())
                 .orElseThrow(() -> new UserDoesNotExistException(friendRequestRequest.receiverUsername()));

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/service/user/UserServiceImpl.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/service/user/UserServiceImpl.java
@@ -1,6 +1,7 @@
 package app.sportahub.userservice.service.user;
 
 import app.sportahub.userservice.client.KeycloakApiClient;
+import app.sportahub.userservice.dto.request.user.FriendRequestRequest;
 import app.sportahub.userservice.dto.response.user.FriendRequestResponse;
 import app.sportahub.userservice.dto.request.user.ProfileRequest;
 import app.sportahub.userservice.dto.request.user.UserRequest;
@@ -149,11 +150,11 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public FriendRequestResponse sendFriendRequest(String userId, String receiverUsername) {
+    public FriendRequestResponse sendFriendRequest(String userId, FriendRequestRequest friendRequestRequest) {
         User userSender = userRepository.findById(userId)
                 .orElseThrow(() -> new UserDoesNotExistException(userId));
-        User userReceiver = userRepository.findUserByUsername(receiverUsername)
-                .orElseThrow(() -> new UserDoesNotExistException(receiverUsername));
+        User userReceiver = userRepository.findUserByUsername(friendRequestRequest.receiverUsername())
+                .orElseThrow(() -> new UserDoesNotExistException(friendRequestRequest.receiverUsername()));
 
         if (userSender.equals(userReceiver)) {
             throw new UserSentFriendRequestToSelfException();

--- a/Microservices/user-service/src/test/java/app/sportahub/userservice/controller/AuthControllerTest.java
+++ b/Microservices/user-service/src/test/java/app/sportahub/userservice/controller/AuthControllerTest.java
@@ -98,7 +98,7 @@ public class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(sendVerificationEmailRequest)))
                 .andExpect(status().isNotFound())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.error").value("User with id:" + sendVerificationEmailRequest.email() + "does not exist."));
+                .andExpect(MockMvcResultMatchers.jsonPath("$.error").value("User with identifier: " + sendVerificationEmailRequest.email() + " does not exist."));
     }
     @SneakyThrows
     @Test

--- a/Microservices/user-service/src/test/java/app/sportahub/userservice/service/user/UserServiceTest.java
+++ b/Microservices/user-service/src/test/java/app/sportahub/userservice/service/user/UserServiceTest.java
@@ -29,6 +29,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Mono;
 
+import java.sql.Array;
 import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -86,7 +87,8 @@ public class UserServiceTest {
                 "testUser",
                 "123",
                 profileRequest,
-                preferences
+                preferences,
+                new ArrayList<>()
         );
         return userRequest;
     }
@@ -235,7 +237,7 @@ public class UserServiceTest {
         );
 
         assertEquals(
-                "404 NOT_FOUND \"User with id:" + userId + "does not exist.\"",
+                "404 NOT_FOUND \"User with identifier: " + userId + " does not exist.\"",
                 exception.getMessage()
         );
     }
@@ -319,7 +321,7 @@ public class UserServiceTest {
         UserDoesNotExistException exception = assertThrows(UserDoesNotExistException.class,
                 () -> userService.updateUserProfile("1", profileRequest));
 
-        assertEquals("404 NOT_FOUND \"User with id:1does not exist.\"", exception.getMessage());
+        assertEquals("404 NOT_FOUND \"User with identifier: 1 does not exist.\"", exception.getMessage());
 
         verify(userRepository, times(1)).findUserById("1");
         verify(userRepository, never()).save(any(User.class));
@@ -350,7 +352,7 @@ public class UserServiceTest {
                 null
         );
 
-        Optional<User> optionalExistingUser = Optional.of(new User("keycloak-123", "test@gmail.com", "testusername", existingProfile, null));
+        Optional<User> optionalExistingUser = Optional.of(new User("keycloak-123", "test@gmail.com", "testusername", existingProfile, null, null));
         User existingUser = optionalExistingUser.get();
         when(userRepository.findUserById(existingUser.getId())).thenReturn(optionalExistingUser);
         existingUser.getProfile().setDateOfBirth(profileRequest.dateOfBirth());
@@ -375,7 +377,7 @@ public class UserServiceTest {
         UserDoesNotExistException exception = assertThrows(UserDoesNotExistException.class,
                 () -> userService.patchUserProfile("1", profileRequest));
 
-        assertEquals("404 NOT_FOUND \"User with id:1does not exist.\"", exception.getMessage());
+        assertEquals("404 NOT_FOUND \"User with identifier: 1 does not exist.\"", exception.getMessage());
 
         verify(userRepository, times(1)).findUserById("1");
         verify(userRepository, never()).save(any(User.class));


### PR DESCRIPTION
Created a new endpoint /user/{userId}/friends/requests to send friend requests to other users.

The sendFrindRequest method inside UserServiceImpl verifies the following:
- that the sender and receiver are existing users
- that the sender hasn't sent a friend request to this user already
- that the sender hasn't sent a friend request to themselves

A new Friend object was created to keep track of friends. It contains String username and FriendRequestStatusEnum status.
The User model was modified to include an Array List of Type Friend.

The FriendRequestStatusEnum has 3 possible values: "SENT", "RECEIVED", and "ACCEPTED"

When the sendFriendRequest method executes successfully, a friend is added to the friend list of both the sender and receiver with appropriate information.
