### PR TITLE
GH-205: bug fix for profile page information fetch

### DIFF
--- a/ClientApp/package.json
+++ b/ClientApp/package.json
@@ -102,6 +102,7 @@
     "@types/react": "~18.2.45",
     "@types/react-native": "^0.73.0",
     "@types/react-test-renderer": "^18.0.7",
+    "@types/redux-mock-store": "^1.5.0",
     "axios": "^1.7.7",
     "axios-mock-adapter": "^2.1.0",
     "babel-jest": "^29.7.0",
@@ -116,6 +117,7 @@
     "jest": "^29.7.0",
     "jest-expo": "~51.0.3",
     "react-test-renderer": "18.2.0",
+    "redux-mock-store": "^1.5.5",
     "ts-jest": "^29.2.5",
     "typescript": "~5.3.3"
   }

--- a/ClientApp/utils/api/profileApiClient.ts
+++ b/ClientApp/utils/api/profileApiClient.ts
@@ -13,3 +13,13 @@ export async function registerProfile(profile: Profile, userId: string) {
         throw error.response?.data || error;
     }
 }
+
+export async function getProfile(userId: string) {
+    try{
+        const response = await axiosInstance.get<Profile>(API_ENDPOINTS.GET_USER_BY_ID.replace('{id}', userId));
+        return response.data;
+    } catch (error: any){
+        console.error('Error fetching profile:', error);
+        throw error.response?.data || error;
+    }
+}

--- a/ClientApp/utils/helpers/ageOfUser.ts
+++ b/ClientApp/utils/helpers/ageOfUser.ts
@@ -1,0 +1,15 @@
+import { UserState } from '@/types/user';
+
+export function calculateAge(user: UserState): number {
+    if (!user.profile.dateOfBirth) {
+        throw new Error ("Date of birth is not provided");
+    }
+    const dob = new Date(user.profile.dateOfBirth);
+    const today = new Date();
+    let age = today.getFullYear() - dob.getFullYear();
+    const monthDifference = today.getMonth() - dob.getMonth();
+    if (monthDifference < 0 || (monthDifference === 0 && today.getDate() < dob.getDate())) {
+        age--;
+    }
+    return age;
+}


### PR DESCRIPTION
fix for #205 Before the profile page was using a json server awaiting the major infrastructure changes that were recently updated

the page would show defaulted values for the fields instead of the user information as per image below

![image](https://github.com/user-attachments/assets/1f88dfa2-ea97-4eb8-81e2-3c0a1a90b7fd)
![image](https://github.com/user-attachments/assets/794ebb2f-1067-42fc-a250-520d4a8d996b)

the console would receive error due to the wrong endpoint 

![image](https://github.com/user-attachments/assets/444d4c3a-e6f5-46e3-b1f6-5eb31e817411)

After the fix: 
The profile page shows the logged user information from the backend
![image](https://github.com/user-attachments/assets/343eb44b-2326-4b71-a6dc-923e01e3cec6)

![image](https://github.com/user-attachments/assets/00915c0e-1d66-4814-be1a-5afb0e73a3f6)

