### PR TITLE
GH-209: [feature] Created endpoint for viewing received friend requests.

### DIFF
--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/controller/user/UserController.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/controller/user/UserController.java
@@ -1,12 +1,13 @@
 package app.sportahub.userservice.controller.user;
 
 import app.sportahub.userservice.dto.request.user.FriendRequestRequest;
-import app.sportahub.userservice.dto.response.user.FriendRequestResponse;
+import app.sportahub.userservice.dto.response.user.friend.FriendRequestResponse;
 import app.sportahub.userservice.dto.request.user.ProfileRequest;
 import app.sportahub.userservice.dto.request.user.UserRequest;
 import app.sportahub.userservice.dto.response.user.ProfileResponse;
 import app.sportahub.userservice.dto.response.user.UserResponse;
 import app.sportahub.userservice.dto.response.user.badge.BadgeWithCountResponse;
+import app.sportahub.userservice.dto.response.user.friend.ViewFriendRequestsResponse;
 import app.sportahub.userservice.service.user.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -76,4 +77,13 @@ public class UserController {
     public FriendRequestResponse sendFriendRequest(@PathVariable String userId, @RequestBody FriendRequestRequest friendRequestRequest) {
         return userService.sendFriendRequest(userId, friendRequestRequest);
     }
+
+    @GetMapping("/{userId}/friend-requests")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "view received friend requests",
+    description = "Retrieves all the user's friend requests stored in their friend list.")
+    public List<ViewFriendRequestsResponse> getFriendRequests(@PathVariable String userId) {
+        return userService.getFriendRequests(userId);
+    }
+
 }

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/controller/user/UserController.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/controller/user/UserController.java
@@ -8,6 +8,7 @@ import app.sportahub.userservice.dto.response.user.ProfileResponse;
 import app.sportahub.userservice.dto.response.user.UserResponse;
 import app.sportahub.userservice.dto.response.user.badge.BadgeWithCountResponse;
 import app.sportahub.userservice.dto.response.user.friend.ViewFriendRequestsResponse;
+import app.sportahub.userservice.enums.user.FriendRequestStatusEnum;
 import app.sportahub.userservice.service.user.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -82,8 +83,7 @@ public class UserController {
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "view received friend requests",
     description = "Retrieves all the user's friend requests stored in their friend list.")
-    public List<ViewFriendRequestsResponse> getFriendRequests(@PathVariable String userId) {
-        return userService.getFriendRequests(userId);
+    public List<ViewFriendRequestsResponse> getFriendRequests(@PathVariable String userId, @RequestParam List<FriendRequestStatusEnum> type) {
+        return userService.getFriendRequests(userId, type);
     }
-
 }

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/dto/response/user/friend/FriendRequestResponse.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/dto/response/user/friend/FriendRequestResponse.java
@@ -1,4 +1,4 @@
-package app.sportahub.userservice.dto.response.user;
+package app.sportahub.userservice.dto.response.user.friend;
 
 public record FriendRequestResponse(String message, String status) {
 }

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/dto/response/user/friend/ViewFriendRequestsResponse.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/dto/response/user/friend/ViewFriendRequestsResponse.java
@@ -1,0 +1,4 @@
+package app.sportahub.userservice.dto.response.user.friend;
+
+public record ViewFriendRequestsResponse(String userName) {
+}

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/exception/GlobalExceptionHandler.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/exception/GlobalExceptionHandler.java
@@ -3,7 +3,7 @@ package app.sportahub.userservice.exception;
 import app.sportahub.userservice.exception.user.InvalidCredentialsException;
 import app.sportahub.userservice.exception.user.UserDoesNotExistException;
 import app.sportahub.userservice.exception.user.UserEmailAlreadyExistsException;
-import app.sportahub.userservice.exception.user.UserSentFriendRequestToSelfException;
+import app.sportahub.userservice.exception.user.friend.UserSentFriendRequestToSelfException;
 import app.sportahub.userservice.exception.user.UserWithEmailDoesNotExistException;
 import app.sportahub.userservice.exception.user.badge.BadgeNotFoundException;
 import app.sportahub.userservice.exception.user.keycloak.KeycloakCommunicationException;

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/exception/user/friend/InvalidFriendRequestStatusTypeException.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/exception/user/friend/InvalidFriendRequestStatusTypeException.java
@@ -1,0 +1,16 @@
+package app.sportahub.userservice.exception.user.friend;
+
+import app.sportahub.userservice.enums.user.FriendRequestStatusEnum;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+@ResponseStatus(code = HttpStatus.BAD_REQUEST, reason = "Invalid friend request status type.")
+public class InvalidFriendRequestStatusTypeException extends ResponseStatusException {
+
+    public InvalidFriendRequestStatusTypeException(FriendRequestStatusEnum status)
+    {
+        super(HttpStatus.BAD_REQUEST, "Invalid friend request status type: "
+                + status.toString() + " for this operation.");
+    }
+}

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/exception/user/friend/UserAlreadyInFriendListException.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/exception/user/friend/UserAlreadyInFriendListException.java
@@ -1,4 +1,4 @@
-package app.sportahub.userservice.exception.user;
+package app.sportahub.userservice.exception.user.friend;
 
 import app.sportahub.userservice.enums.user.FriendRequestStatusEnum;
 import org.springframework.http.HttpStatus;

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/exception/user/friend/UserSentFriendRequestToSelfException.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/exception/user/friend/UserSentFriendRequestToSelfException.java
@@ -1,4 +1,4 @@
-package app.sportahub.userservice.exception.user;
+package app.sportahub.userservice.exception.user.friend;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/service/user/UserService.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/service/user/UserService.java
@@ -8,6 +8,7 @@ import app.sportahub.userservice.dto.response.user.ProfileResponse;
 import app.sportahub.userservice.dto.response.user.UserResponse;
 import app.sportahub.userservice.dto.response.user.badge.BadgeWithCountResponse;
 import app.sportahub.userservice.dto.response.user.friend.ViewFriendRequestsResponse;
+import app.sportahub.userservice.enums.user.FriendRequestStatusEnum;
 
 import java.util.List;
 
@@ -27,5 +28,5 @@ public interface UserService {
 
     FriendRequestResponse sendFriendRequest(String userId, FriendRequestRequest friendRequestRequest);
 
-    List<ViewFriendRequestsResponse> getFriendRequests(String userId);
+    List<ViewFriendRequestsResponse> getFriendRequests(String userId, List<FriendRequestStatusEnum> typeList);
 }

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/service/user/UserService.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/service/user/UserService.java
@@ -1,12 +1,13 @@
 package app.sportahub.userservice.service.user;
 
 import app.sportahub.userservice.dto.request.user.FriendRequestRequest;
-import app.sportahub.userservice.dto.response.user.FriendRequestResponse;
+import app.sportahub.userservice.dto.response.user.friend.FriendRequestResponse;
 import app.sportahub.userservice.dto.request.user.ProfileRequest;
 import app.sportahub.userservice.dto.request.user.UserRequest;
 import app.sportahub.userservice.dto.response.user.ProfileResponse;
 import app.sportahub.userservice.dto.response.user.UserResponse;
 import app.sportahub.userservice.dto.response.user.badge.BadgeWithCountResponse;
+import app.sportahub.userservice.dto.response.user.friend.ViewFriendRequestsResponse;
 
 import java.util.List;
 
@@ -25,4 +26,6 @@ public interface UserService {
     List<BadgeWithCountResponse> getUserBadges(String userId);
 
     FriendRequestResponse sendFriendRequest(String userId, FriendRequestRequest friendRequestRequest);
+
+    List<ViewFriendRequestsResponse> getFriendRequests(String userId);
 }

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/service/user/UserServiceImpl.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/service/user/UserServiceImpl.java
@@ -12,10 +12,11 @@ import app.sportahub.userservice.dto.response.user.badge.BadgeResponse;
 import app.sportahub.userservice.dto.response.user.badge.BadgeWithCountResponse;
 import app.sportahub.userservice.dto.response.user.friend.ViewFriendRequestsResponse;
 import app.sportahub.userservice.enums.user.FriendRequestStatusEnum;
-import app.sportahub.userservice.exception.user.UserAlreadyInFriendListException;
+import app.sportahub.userservice.exception.user.friend.InvalidFriendRequestStatusTypeException;
+import app.sportahub.userservice.exception.user.friend.UserAlreadyInFriendListException;
 import app.sportahub.userservice.exception.user.UserDoesNotExistException;
 import app.sportahub.userservice.exception.user.UserEmailAlreadyExistsException;
-import app.sportahub.userservice.exception.user.UserSentFriendRequestToSelfException;
+import app.sportahub.userservice.exception.user.friend.UserSentFriendRequestToSelfException;
 import app.sportahub.userservice.exception.user.UsernameAlreadyExistsException;
 import app.sportahub.userservice.exception.user.badge.BadgeNotFoundException;
 import app.sportahub.userservice.exception.user.badge.UserAlreadyAssignedBadgeByThisGiverException;
@@ -30,7 +31,6 @@ import org.springframework.stereotype.Service;
 
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -188,10 +188,14 @@ public class UserServiceImpl implements UserService {
      */
     @Override
     public List<ViewFriendRequestsResponse> getFriendRequests(String userId, List<FriendRequestStatusEnum> typeList) {
+        if (typeList.contains(FriendRequestStatusEnum.ACCEPTED)) {
+            throw new InvalidFriendRequestStatusTypeException(FriendRequestStatusEnum.ACCEPTED);
+        }
+
         User user = userRepository.findUserById(userId)
                 .orElseThrow(() -> new UserDoesNotExistException(userId));
         List<Friend> friends = user.getFriendList();
-//s.getFriendRequestStatus().equals(Arrays.asList(typeList).containsFriendRequestStatusEnum.RECEIVED)
+
         return friends.stream()
                 .filter(s -> typeList.contains(s.getFriendRequestStatus()) )
                 .map(friend -> new ViewFriendRequestsResponse(friend.getUsername())).toList();

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/service/user/UserServiceImpl.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/service/user/UserServiceImpl.java
@@ -2,7 +2,7 @@ package app.sportahub.userservice.service.user;
 
 import app.sportahub.userservice.client.KeycloakApiClient;
 import app.sportahub.userservice.dto.request.user.FriendRequestRequest;
-import app.sportahub.userservice.dto.response.user.FriendRequestResponse;
+import app.sportahub.userservice.dto.response.user.friend.FriendRequestResponse;
 import app.sportahub.userservice.dto.request.user.ProfileRequest;
 import app.sportahub.userservice.dto.request.user.UserRequest;
 import app.sportahub.userservice.dto.request.user.keycloak.KeycloakRequest;
@@ -10,6 +10,7 @@ import app.sportahub.userservice.dto.response.user.ProfileResponse;
 import app.sportahub.userservice.dto.response.user.UserResponse;
 import app.sportahub.userservice.dto.response.user.badge.BadgeResponse;
 import app.sportahub.userservice.dto.response.user.badge.BadgeWithCountResponse;
+import app.sportahub.userservice.dto.response.user.friend.ViewFriendRequestsResponse;
 import app.sportahub.userservice.enums.user.FriendRequestStatusEnum;
 import app.sportahub.userservice.exception.user.UserAlreadyInFriendListException;
 import app.sportahub.userservice.exception.user.UserDoesNotExistException;
@@ -175,5 +176,23 @@ public class UserServiceImpl implements UserService {
         log.info("UserServiceImpl::sendFriendRequest: User with id:{} received a new friend request", savedUser.getId());
 
         return new FriendRequestResponse("Friend request sent successfully.", userReceiver.getUsername());
+    }
+
+    /**
+     * This method returns the usernames of all the users who sent a friend request to the user with the given user id.
+     *
+     * @param userId The user id of the user whose friends requests you want to retrieve
+     * @return a list of {@link ViewFriendRequestsResponse} containing the usernames of the users who sent a friend request
+     * @throws UserDoesNotExistException if the given user id doesn't correspond to a user
+     */
+    @Override
+    public List<ViewFriendRequestsResponse> getFriendRequests(String userId) {
+        User user = userRepository.findUserById(userId)
+                .orElseThrow(() -> new UserDoesNotExistException(userId));
+        List<Friend> friends = user.getFriendList();
+
+        return friends.stream()
+                .filter(s -> s.getFriendRequestStatus().equals(FriendRequestStatusEnum.RECEIVED))
+                .map(friend -> new ViewFriendRequestsResponse(friend.getUsername())).toList();
     }
 }

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/service/user/UserServiceImpl.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/service/user/UserServiceImpl.java
@@ -30,6 +30,7 @@ import org.springframework.stereotype.Service;
 
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -186,13 +187,13 @@ public class UserServiceImpl implements UserService {
      * @throws UserDoesNotExistException if the given user id doesn't correspond to a user
      */
     @Override
-    public List<ViewFriendRequestsResponse> getFriendRequests(String userId) {
+    public List<ViewFriendRequestsResponse> getFriendRequests(String userId, List<FriendRequestStatusEnum> typeList) {
         User user = userRepository.findUserById(userId)
                 .orElseThrow(() -> new UserDoesNotExistException(userId));
         List<Friend> friends = user.getFriendList();
-
+//s.getFriendRequestStatus().equals(Arrays.asList(typeList).containsFriendRequestStatusEnum.RECEIVED)
         return friends.stream()
-                .filter(s -> s.getFriendRequestStatus().equals(FriendRequestStatusEnum.RECEIVED))
+                .filter(s -> typeList.contains(s.getFriendRequestStatus()) )
                 .map(friend -> new ViewFriendRequestsResponse(friend.getUsername())).toList();
     }
 }

--- a/Microservices/user-service/src/test/java/app/sportahub/userservice/service/user/UserServiceTest.java
+++ b/Microservices/user-service/src/test/java/app/sportahub/userservice/service/user/UserServiceTest.java
@@ -620,12 +620,15 @@ public class UserServiceTest {
         friendList.add(new Friend("sender", FriendRequestStatusEnum.SENT));
         friendList.add(new Friend("receiver", FriendRequestStatusEnum.RECEIVED));
         user.setFriendList(friendList);
+        List<FriendRequestStatusEnum> typeList = new ArrayList<>();
+        typeList.add(FriendRequestStatusEnum.RECEIVED);
+
 
         // Act
         when(userRepository.findUserById("id")).thenReturn(Optional.of(user));
 
         // Assert
-        List<ViewFriendRequestsResponse> listResponse = userService.getFriendRequests("id");
+        List<ViewFriendRequestsResponse> listResponse = userService.getFriendRequests("id", typeList);
         assertFalse(listResponse.isEmpty());
         assertEquals(1, listResponse.size());
         assertEquals("receiver", listResponse.getFirst().userName());
@@ -635,10 +638,12 @@ public class UserServiceTest {
     void getFriendRequestsShouldThrowUserDoesNotExistException() {
         // Arrange
         String userId = new ObjectId().toHexString();
+        List<FriendRequestStatusEnum> typeList = new ArrayList<>();
+        typeList.add(FriendRequestStatusEnum.RECEIVED);
 
         // Act
         UserDoesNotExistException exception = assertThrows(UserDoesNotExistException.class,
-                () -> userService.getFriendRequests(userId));
+                () -> userService.getFriendRequests(userId, typeList));
 
         // Assert
         assertEquals("404 NOT_FOUND \"User with identifier: " + userId + " does not exist.\"", exception.getMessage());

--- a/Microservices/user-service/src/test/java/app/sportahub/userservice/service/user/UserServiceTest.java
+++ b/Microservices/user-service/src/test/java/app/sportahub/userservice/service/user/UserServiceTest.java
@@ -632,7 +632,7 @@ public class UserServiceTest {
     }
 
     @Test
-    void getFriendRequestsShouldThrowUserNotFoundException() {
+    void getFriendRequestsShouldThrowUserDoesNotExistException() {
         // Arrange
         String userId = new ObjectId().toHexString();
 


### PR DESCRIPTION
This PR is for the /user/{userId}/friend-requests endpoint which returns a list of received friend requests for the user with the corresponding userId.

The user service method goes through the user's friend list and filters out every friend whose status is not "RECEIVED", then returns this list as a List<ViewFriendRequestsResponse> object that contains all usernames of the users who sent a friend request.

the user service method throws a UserDoesNotExistException if the given userId does not correspond to a valid user.