### PR TITLE
GH-220:[fix] FIx CI failing test

### DIFF
--- a/ClientApp/jest.setup.ts
+++ b/ClientApp/jest.setup.ts
@@ -1,0 +1,3 @@
+// jestSetup.ts
+
+jest.mock("expo-font");

--- a/ClientApp/package.json
+++ b/ClientApp/package.json
@@ -10,14 +10,14 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "test": "jest --transformIgnorePatterns \"node_modules/(?!@toolz/allow)/\" --env=jsdom",
-    "ci-test": "jest --transformIgnorePatterns \"node_modules/(?!@toolz/allow)/\" --env=jsdom --coverage",
+    "test": "jest --transformIgnorePatterns \"node_modules/(?!@toolz/allow|expo-font)/\" --env=jsdom",
+    "ci-test": "jest --transformIgnorePatterns \"node_modules/(?!@toolz/allow|expo-font)/\" --env=jsdom --coverage",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "jest": {
     "preset": "jest-expo",
     "setupFilesAfterEnv": [
-      "<rootDir>/jestSetup.ts",
+      "<rootDir>/jest.setup.ts",
       "@testing-library/jest-native/extend-expect"
     ],
     "moduleNameMapper": {


### PR DESCRIPTION
Failing frontend CI test because of the SDK migration.

The following solution includes the proper modifications to the package.json and jest.setup.ts