### PR TITLE
GH-225: [fix] Allow patch and head operations through Swagger

### DIFF
--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/config/WebConfig.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/config/WebConfig.java
@@ -15,7 +15,7 @@ public class WebConfig {
             public void addCorsMappings(CorsRegistry registry) {
                 registry.addMapping("/**")
                         .allowedOrigins("http://localhost:8080", "https://api-dev.sportahub.app", "https://api.sportahub.app")
-                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                        .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD")
                         .allowedHeaders("*")
                         .allowCredentials(true);
             }

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/config/auth/WebConfig.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/config/auth/WebConfig.java
@@ -15,7 +15,7 @@ public class WebConfig {
             public void addCorsMappings(CorsRegistry registry) {
                 registry.addMapping("/**")
                         .allowedOrigins("http://localhost:8080", "https://api-dev.sportahub.app", "https://api.sportahub.app")
-                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                        .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD")
                         .allowedHeaders("*")
                         .allowCredentials(true);
             }


### PR DESCRIPTION
### Description  
This pull request addresses issue #225 by updating the CORS configuration in both `event-service` and `user-service` to include support for PATCH and HEAD methods. Previously, these methods were not allowed in Swagger, though they worked correctly in Postman.

**Changes Made:**  
- Updated the `allowedMethods` in `WebConfig.java` to include `"PATCH"` and `"HEAD"`.  
- Adjusted CORS policies for both `event-service` and `user-service` to enable seamless testing and execution of these methods via Swagger UI.

**Closing Keywords:**  
This PR closes #225.

---

### Testing  
1. Verified the updated CORS configuration by running the services locally.  
2. Successfully executed PATCH and HEAD operations through Swagger UI.  
3. Cross-verified the operations' functionality in Postman to ensure consistency.  

---

### Impact  
These changes ensure that all HTTP methods (GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD) are properly supported through Swagger UI. This improves the usability and testing capabilities for developers.  
