### PR TITLE
GH-210: [feature] Created an endpoint to Accept or Decline friend requests

### DIFF
--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/controller/user/UserController.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/controller/user/UserController.java
@@ -1,12 +1,14 @@
 package app.sportahub.userservice.controller.user;
 
-import app.sportahub.userservice.dto.request.user.FriendRequestRequest;
+import app.sportahub.userservice.dto.request.user.friend.FriendRequestRequest;
+import app.sportahub.userservice.dto.request.user.friend.UpdateFriendRequestRequest;
 import app.sportahub.userservice.dto.response.user.friend.FriendRequestResponse;
 import app.sportahub.userservice.dto.request.user.ProfileRequest;
 import app.sportahub.userservice.dto.request.user.UserRequest;
 import app.sportahub.userservice.dto.response.user.ProfileResponse;
 import app.sportahub.userservice.dto.response.user.UserResponse;
 import app.sportahub.userservice.dto.response.user.badge.BadgeWithCountResponse;
+import app.sportahub.userservice.dto.response.user.friend.UpdateFriendRequestResponse;
 import app.sportahub.userservice.dto.response.user.friend.ViewFriendRequestsResponse;
 import app.sportahub.userservice.enums.user.FriendRequestStatusEnum;
 import app.sportahub.userservice.service.user.UserService;
@@ -75,8 +77,18 @@ public class UserController {
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "Send a friend request to a user",
     description = "Allows a user to send a friend request to another user and returns the details of the friend request.")
-    public FriendRequestResponse sendFriendRequest(@PathVariable String userId, @RequestBody FriendRequestRequest friendRequestRequest) {
+    public FriendRequestResponse sendFriendRequest(@PathVariable String userId,
+                                                   @Valid @RequestBody FriendRequestRequest friendRequestRequest) {
         return userService.sendFriendRequest(userId, friendRequestRequest);
+    }
+
+    @PutMapping("/{userId}/friend-requests/{requestId}")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "Accept or decline a friend request",
+    description = "Allows a user to accept or decline a friend request and returns a success message if successful.")
+    public UpdateFriendRequestResponse updateFriendRequest(@PathVariable String userId, @PathVariable String requestId,
+                                                           @Valid @RequestBody UpdateFriendRequestRequest updateFriendRequestRequest) {
+        return userService.updateFriendRequest(userId, requestId, updateFriendRequestRequest);
     }
 
     @GetMapping("/{userId}/friend-requests")

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/dto/request/user/friend/FriendRequestRequest.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/dto/request/user/friend/FriendRequestRequest.java
@@ -1,4 +1,4 @@
-package app.sportahub.userservice.dto.request.user;
+package app.sportahub.userservice.dto.request.user.friend;
 
 public record FriendRequestRequest(String receiverUsername) {
 }

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/dto/request/user/friend/UpdateFriendRequestRequest.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/dto/request/user/friend/UpdateFriendRequestRequest.java
@@ -1,0 +1,6 @@
+package app.sportahub.userservice.dto.request.user.friend;
+
+import app.sportahub.userservice.enums.user.UpdateFriendRequestActionEnum;
+
+public record UpdateFriendRequestRequest(String friendUsername, UpdateFriendRequestActionEnum action) {
+}

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/dto/response/user/friend/UpdateFriendRequestResponse.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/dto/response/user/friend/UpdateFriendRequestResponse.java
@@ -1,0 +1,4 @@
+package app.sportahub.userservice.dto.response.user.friend;
+
+public record UpdateFriendRequestResponse(String message) {
+}

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/enums/user/UpdateFriendRequestActionEnum.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/enums/user/UpdateFriendRequestActionEnum.java
@@ -1,0 +1,5 @@
+package app.sportahub.userservice.enums.user;
+
+public enum UpdateFriendRequestActionEnum {
+    ACCEPT,DECLINE
+}

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/exception/GlobalExceptionHandler.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/exception/GlobalExceptionHandler.java
@@ -3,7 +3,7 @@ package app.sportahub.userservice.exception;
 import app.sportahub.userservice.exception.user.InvalidCredentialsException;
 import app.sportahub.userservice.exception.user.UserDoesNotExistException;
 import app.sportahub.userservice.exception.user.UserEmailAlreadyExistsException;
-import app.sportahub.userservice.exception.user.friend.UserSentFriendRequestToSelfException;
+import app.sportahub.userservice.exception.user.friend.*;
 import app.sportahub.userservice.exception.user.UserWithEmailDoesNotExistException;
 import app.sportahub.userservice.exception.user.badge.BadgeNotFoundException;
 import app.sportahub.userservice.exception.user.keycloak.KeycloakCommunicationException;
@@ -99,5 +99,45 @@ public class GlobalExceptionHandler {
         response.put("error", ex.getMessage());
         response.put("status", HttpStatus.BAD_REQUEST.value());
         return ResponseEntity.badRequest().body(response);
+    }
+
+    @ExceptionHandler(FriendDoesNotExistException.class)
+    public ResponseEntity<Map<String, Object>> handleFriendDoesNotExistException(FriendDoesNotExistException ex) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("error", ex.getMessage());
+        response.put("status", HttpStatus.NOT_FOUND.value());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+    }
+
+    @ExceptionHandler(FriendNotFoundInFriendListException.class)
+    public ResponseEntity<Map<String, Object>> handleFriendNotFoundInFriendListException(FriendNotFoundInFriendListException ex) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("error", ex.getMessage());
+        response.put("status", HttpStatus.NOT_FOUND.value());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+    }
+
+    @ExceptionHandler(GivenFriendUsernameDoesNotMatchFriendFoundByIdException.class)
+    public ResponseEntity<Map<String,Object>> handleGivenFriendUsernameDoesNotMatchFriendFoundById(GivenFriendUsernameDoesNotMatchFriendFoundByIdException ex) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("error", ex.getMessage());
+        response.put("status", HttpStatus.CONFLICT.value());
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
+    }
+
+    @ExceptionHandler(UnexpectedUpdateFriendRequestActionException.class)
+    public ResponseEntity<Map<String, Object>> handleUnexpectedUpdateFriendRequestActionException(UnexpectedUpdateFriendRequestActionException ex) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("error", ex.getMessage());
+        response.put("status", HttpStatus.BAD_REQUEST.value());
+        return ResponseEntity.badRequest().body(response);
+    }
+
+    @ExceptionHandler(UserAlreadyInFriendListException.class)
+    public ResponseEntity<Map<String, Object>> handleUserAlreadyInFriendListException(UserAlreadyInFriendListException ex) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("error", ex.getMessage());
+        response.put("status", HttpStatus.CONFLICT.value());
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
     }
 }

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/exception/user/friend/FriendDoesNotExistException.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/exception/user/friend/FriendDoesNotExistException.java
@@ -1,0 +1,12 @@
+package app.sportahub.userservice.exception.user.friend;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+@ResponseStatus(code = HttpStatus.NOT_FOUND, reason = "Friend does not exist.")
+public class FriendDoesNotExistException extends ResponseStatusException {
+    public FriendDoesNotExistException(String identifier) {
+        super(HttpStatus.NOT_FOUND, "Friend with identifier: " + identifier + " does not exist.");
+    }
+}

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/exception/user/friend/FriendNotFoundInFriendListException.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/exception/user/friend/FriendNotFoundInFriendListException.java
@@ -1,0 +1,14 @@
+package app.sportahub.userservice.exception.user.friend;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+@ResponseStatus(code = HttpStatus.NOT_FOUND, reason = "Friend not found in user's friend list.")
+public class FriendNotFoundInFriendListException extends ResponseStatusException {
+
+    public FriendNotFoundInFriendListException(String userIdentifier, String friendIdentifier) {
+        super(HttpStatus.NOT_FOUND, "User with identifier " + userIdentifier
+                + " does not have friend with identifier " + friendIdentifier + " in their friend list." );
+    }
+}

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/exception/user/friend/FriendNotFoundInFriendListException.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/exception/user/friend/FriendNotFoundInFriendListException.java
@@ -8,7 +8,7 @@ import org.springframework.web.server.ResponseStatusException;
 public class FriendNotFoundInFriendListException extends ResponseStatusException {
 
     public FriendNotFoundInFriendListException(String userIdentifier, String friendIdentifier) {
-        super(HttpStatus.NOT_FOUND, "User with identifier " + userIdentifier
-                + " does not have friend with identifier " + friendIdentifier + " in their friend list." );
+        super(HttpStatus.NOT_FOUND, "User with identifier: " + userIdentifier
+                + " does not have friend with identifier: " + friendIdentifier + " in their friend list." );
     }
 }

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/exception/user/friend/GivenFriendUsernameDoesNotMatchFriendFoundByIdException.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/exception/user/friend/GivenFriendUsernameDoesNotMatchFriendFoundByIdException.java
@@ -1,0 +1,14 @@
+package app.sportahub.userservice.exception.user.friend;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+@ResponseStatus(code = HttpStatus.CONFLICT,
+        reason = "Given friend username does not match the friend found by the given request id.")
+public class GivenFriendUsernameDoesNotMatchFriendFoundByIdException extends ResponseStatusException {
+    public GivenFriendUsernameDoesNotMatchFriendFoundByIdException(String friendUsername, String requestId) {
+        super(HttpStatus.CONFLICT, "Given friend with the username: " + friendUsername
+                + " does not match the friend found with the given request id: " + requestId);
+    }
+}

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/exception/user/friend/TryingToAcceptInvalidFriendRequestException.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/exception/user/friend/TryingToAcceptInvalidFriendRequestException.java
@@ -1,0 +1,18 @@
+package app.sportahub.userservice.exception.user.friend;
+
+import app.sportahub.userservice.enums.user.FriendRequestStatusEnum;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+@ResponseStatus(code = HttpStatus.CONFLICT, reason = "Trying to accept a friend request not labelled as RECEIVED.")
+public class TryingToAcceptInvalidFriendRequestException extends ResponseStatusException {
+
+    public TryingToAcceptInvalidFriendRequestException(String userIdentifier,
+                                                       String friendIdentifier, FriendRequestStatusEnum status) {
+
+        super(HttpStatus.CONFLICT, "User with identifier: " + userIdentifier
+                + " is trying to accept a friend request from: " + friendIdentifier
+                + " but the status of the friend request is " + status + " instead of RECEIVED.");
+    }
+}

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/exception/user/friend/UnexpectedUpdateFriendRequestActionException.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/exception/user/friend/UnexpectedUpdateFriendRequestActionException.java
@@ -1,0 +1,15 @@
+package app.sportahub.userservice.exception.user.friend;
+
+import app.sportahub.userservice.enums.user.UpdateFriendRequestActionEnum;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+@ResponseStatus(code = HttpStatus.BAD_REQUEST, reason = "The provided action is not valid.")
+public class UnexpectedUpdateFriendRequestActionException extends ResponseStatusException {
+
+    public UnexpectedUpdateFriendRequestActionException(UpdateFriendRequestActionEnum action) {
+        super(HttpStatus.BAD_REQUEST, "The provided action: " + action.toString()
+                + " is unexpected and therefore invalid.");
+    }
+}

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/model/user/Friend.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/model/user/Friend.java
@@ -1,17 +1,19 @@
 package app.sportahub.userservice.model.user;
 
 import app.sportahub.userservice.enums.user.FriendRequestStatusEnum;
+import app.sportahub.userservice.model.BaseEntity;
 import jakarta.validation.constraints.NotBlank;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.mongodb.core.mapping.Document;
 
-@Builder(setterPrefix = "with")
+@SuperBuilder(toBuilder = true, setterPrefix = "with")
+@EqualsAndHashCode(callSuper=false)
 @AllArgsConstructor
 @NoArgsConstructor
+@Document("friend")
 @Data
-public class Friend {
+public class Friend extends BaseEntity {
 
     @NotBlank(message = "Username of friend must be provided.")
     private String username;

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/repository/FriendRepository.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/repository/FriendRepository.java
@@ -1,0 +1,15 @@
+package app.sportahub.userservice.repository;
+
+import app.sportahub.userservice.model.user.Friend;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface FriendRepository extends MongoRepository<Friend, String> {
+
+    Optional<Friend> findFriendByUsername(String username);
+
+    Optional<Friend> findFriendById(String id);
+}

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/service/user/UserService.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/service/user/UserService.java
@@ -1,12 +1,14 @@
 package app.sportahub.userservice.service.user;
 
-import app.sportahub.userservice.dto.request.user.FriendRequestRequest;
+import app.sportahub.userservice.dto.request.user.friend.FriendRequestRequest;
+import app.sportahub.userservice.dto.request.user.friend.UpdateFriendRequestRequest;
 import app.sportahub.userservice.dto.response.user.friend.FriendRequestResponse;
 import app.sportahub.userservice.dto.request.user.ProfileRequest;
 import app.sportahub.userservice.dto.request.user.UserRequest;
 import app.sportahub.userservice.dto.response.user.ProfileResponse;
 import app.sportahub.userservice.dto.response.user.UserResponse;
 import app.sportahub.userservice.dto.response.user.badge.BadgeWithCountResponse;
+import app.sportahub.userservice.dto.response.user.friend.UpdateFriendRequestResponse;
 import app.sportahub.userservice.dto.response.user.friend.ViewFriendRequestsResponse;
 import app.sportahub.userservice.enums.user.FriendRequestStatusEnum;
 
@@ -27,6 +29,9 @@ public interface UserService {
     List<BadgeWithCountResponse> getUserBadges(String userId);
 
     FriendRequestResponse sendFriendRequest(String userId, FriendRequestRequest friendRequestRequest);
+
+    UpdateFriendRequestResponse updateFriendRequest(String userId, String requestId,
+                                                    UpdateFriendRequestRequest updateFriendRequestRequest);
 
     List<ViewFriendRequestsResponse> getFriendRequests(String userId, List<FriendRequestStatusEnum> typeList);
 }

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/service/user/UserServiceImpl.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/service/user/UserServiceImpl.java
@@ -227,6 +227,11 @@ public class UserServiceImpl implements UserService {
 
         for (Friend e : userFriendList) {
             if (e.getUsername().equals(friend.getUsername())) {
+                if (!e.getFriendRequestStatus().equals(FriendRequestStatusEnum.RECEIVED) &&
+                        action.equals(UpdateFriendRequestActionEnum.ACCEPT)) {
+                    throw new TryingToAcceptInvalidFriendRequestException(user.getUsername(),
+                            friendUser.getUsername(), e.getFriendRequestStatus());
+                }
                 isFriendFound1 = true;
                 if (action.equals(UpdateFriendRequestActionEnum.ACCEPT)) {
                     e.setFriendRequestStatus(FriendRequestStatusEnum.ACCEPTED);

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/service/user/UserServiceImpl.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/service/user/UserServiceImpl.java
@@ -216,7 +216,7 @@ public class UserServiceImpl implements UserService {
                 .build();
 
         if (!friend.getUsername().equals(friendUser.getUsername())) {
-            throw new GivenFriendUsernameDoesNotMatchFriendFoundByIdException(friendUser.getUsername(), friend.getUsername());
+            throw new GivenFriendUsernameDoesNotMatchFriendFoundByIdException(friendUser.getUsername(), requestId);
         }
 
         UpdateFriendRequestActionEnum action = updateFriendRequestRequest.action();
@@ -239,8 +239,9 @@ public class UserServiceImpl implements UserService {
                         if (action.equals(UpdateFriendRequestActionEnum.ACCEPT)) {
                             el.setFriendRequestStatus(FriendRequestStatusEnum.ACCEPTED);
                         } else if (action.equals(UpdateFriendRequestActionEnum.DECLINE)) {
-                            userFriendList.remove(el);
+                            friendUserFriendList.remove(el);
                         }
+                        break;
                     }
                 }
                 break;
@@ -253,24 +254,24 @@ public class UserServiceImpl implements UserService {
             throw new FriendNotFoundInFriendListException(friendUser.getUsername(), user.getUsername());
 
         user.setFriendList(userFriendList);
-        User savedUser = userRepository.save(user);
+        userRepository.save(user);
         friendUser.setFriendList(friendUserFriendList);
-        User savedFriendUser = userRepository.save(friendUser);
+        userRepository.save(friendUser);
         String responseMessage;
 
         if (action.equals(UpdateFriendRequestActionEnum.ACCEPT)) {
             log.info("UserServiceImpl::updateFriendRequest: User with id:{} accepted the friend request of user with id:{}",
-                    savedUser.getId(), savedFriendUser.getId());
+                    user.getId(), friendUser.getId());
 
-            responseMessage = "User with username: " + savedUser.getUsername()
-                    + " accepted the friend request of user with username" + savedFriendUser.getUsername() + " successfully";
+            responseMessage = "User with username: " + user.getUsername()
+                    + " accepted the friend request of user with username: " + friendUser.getUsername() + " successfully";
 
         } else if (action.equals(UpdateFriendRequestActionEnum.DECLINE)) {
             log.info("UserServiceImpl::updateFriendRequest: User with id:{} declined the friend request of user with id:{}",
-                    savedUser.getId(), savedFriendUser.getId());
+                    user.getId(), friendUser.getId());
 
-            responseMessage = "User with username: " + savedUser.getUsername()
-                    + " declined the friend request of user with username" + savedFriendUser.getUsername() + " successfully";
+            responseMessage = "User with username: " + user.getUsername()
+                    + " declined the friend request of user with username: " + friendUser.getUsername() + " successfully";
         } else {
             throw new UnexpectedUpdateFriendRequestActionException(action);
         }

--- a/Microservices/user-service/src/test/java/app/sportahub/userservice/service/user/UserServiceTest.java
+++ b/Microservices/user-service/src/test/java/app/sportahub/userservice/service/user/UserServiceTest.java
@@ -3,20 +3,19 @@ package app.sportahub.userservice.service.user;
 import app.sportahub.userservice.client.KeycloakApiClient;
 import app.sportahub.userservice.dto.request.user.*;
 import app.sportahub.userservice.dto.request.user.friend.FriendRequestRequest;
+import app.sportahub.userservice.dto.request.user.friend.UpdateFriendRequestRequest;
 import app.sportahub.userservice.dto.request.user.keycloak.KeycloakRequest;
 import app.sportahub.userservice.dto.response.user.friend.FriendRequestResponse;
 import app.sportahub.userservice.dto.response.user.ProfileResponse;
 import app.sportahub.userservice.dto.response.user.SportLevelResponse;
 import app.sportahub.userservice.dto.response.user.UserResponse;
+import app.sportahub.userservice.dto.response.user.friend.UpdateFriendRequestResponse;
 import app.sportahub.userservice.dto.response.user.friend.ViewFriendRequestsResponse;
 import app.sportahub.userservice.enums.user.FriendRequestStatusEnum;
+import app.sportahub.userservice.enums.user.UpdateFriendRequestActionEnum;
 import app.sportahub.userservice.exception.user.*;
 import app.sportahub.userservice.exception.user.badge.UserAlreadyAssignedBadgeByThisGiverException;
-import app.sportahub.userservice.exception.user.friend.UserAlreadyInFriendListException;
-import app.sportahub.userservice.exception.user.friend.UserSentFriendRequestToSelfException;
-import app.sportahub.userservice.exception.user.friend.InvalidFriendRequestStatusTypeException;
-import app.sportahub.userservice.exception.user.friend.UserAlreadyInFriendListException;
-import app.sportahub.userservice.exception.user.friend.UserSentFriendRequestToSelfException;
+import app.sportahub.userservice.exception.user.friend.*;
 import app.sportahub.userservice.mapper.user.ProfileMapper;
 import app.sportahub.userservice.mapper.user.UserMapper;
 import app.sportahub.userservice.model.user.*;
@@ -97,6 +96,47 @@ public class UserServiceTest {
                 new ArrayList<>()
         );
         return userRequest;
+    }
+
+    private Optional<User> getUser(String userID, String username) {
+        return Optional.of(User.builder()
+                .withId(userID)
+                .withEmail(username +"@email.com")
+                        .withUsername(username)
+                .withProfile(Profile.builder()
+                        .withFirstName("John")
+                        .withLastName("Doe")
+                        .withDateOfBirth(LocalDate.of(1990, 1, 1))
+                        .withGender("Male")
+                        .withPostalCode("12345")
+                        .withPhoneNumber("1234567890")
+                        .withSportsOfPreference(
+                                List.of(new SportLevel("Basketball", "Intermediate"),
+                                        new SportLevel("Soccer", "Beginner")))
+                        .withRanking("100")
+                        .build())
+                        .build());
+    }
+
+    private Optional<User> getUser(String userID, String username, List<Friend> friendList) {
+        return Optional.of(User.builder()
+                .withId(userID)
+                .withEmail(username +"@email.com")
+                .withUsername(username)
+                .withProfile(Profile.builder()
+                        .withFirstName("John")
+                        .withLastName("Doe")
+                        .withDateOfBirth(LocalDate.of(1990, 1, 1))
+                        .withGender("Male")
+                        .withPostalCode("12345")
+                        .withPhoneNumber("1234567890")
+                        .withSportsOfPreference(
+                                List.of(new SportLevel("Basketball", "Intermediate"),
+                                        new SportLevel("Soccer", "Beginner")))
+                        .withRanking("100")
+                        .build())
+                        .withFriendList(friendList)
+                .build());
     }
 
     @Test
@@ -451,42 +491,12 @@ public class UserServiceTest {
     void sendFriendRequestShouldReturnSuccess() {
         // Arrange
         String senderId = "sender";
-        Optional<User> sendUser = Optional.of(User.builder()
-                .withId(senderId)
-                .withEmail("test@example.com")
-                .withUsername("sender")
-                .withProfile(Profile.builder()
-                        .withFirstName("John")
-                        .withLastName("Doe")
-                        .withDateOfBirth(LocalDate.of(1990, 1, 1))
-                        .withGender("Male")
-                        .withPostalCode("12345")
-                        .withPhoneNumber("1234567890")
-                        .withSportsOfPreference(
-                                List.of(new SportLevel("Basketball", "Intermediate"),
-                                        new SportLevel("Soccer", "Beginner")))
-                        .withRanking("100")
-                        .build())
-                .build());
+        String senderUsername = "sender";
+        Optional<User> sendUser = getUser(senderId, senderUsername);
 
         String receiverId = "receiver";
-        Optional<User> receiverUser = Optional.of(User.builder()
-                .withId(receiverId)
-                .withEmail("test@example.com")
-                .withUsername("receiver")
-                .withProfile(Profile.builder()
-                        .withFirstName("John")
-                        .withLastName("Doe")
-                        .withDateOfBirth(LocalDate.of(1990, 1, 1))
-                        .withGender("Male")
-                        .withPostalCode("12345")
-                        .withPhoneNumber("1234567890")
-                        .withSportsOfPreference(
-                                List.of(new SportLevel("Basketball", "Intermediate"),
-                                        new SportLevel("Soccer", "Beginner")))
-                        .withRanking("100")
-                        .build())
-                .build());
+        String receiverUsername = "receiver";
+        Optional<User> receiverUser = getUser(receiverId, receiverUsername);
 
         when(userRepository.findUserById(senderId)).thenReturn(sendUser);
         when(userRepository.findUserByUsername(receiverUser.get().getUsername())).thenReturn(receiverUser);
@@ -533,44 +543,12 @@ public class UserServiceTest {
         receiverFriendList.add(new Friend("sender", FriendRequestStatusEnum.RECEIVED));
 
         String senderId = "sender";
-        Optional<User> sendUser = Optional.of(User.builder()
-                .withId(senderId)
-                .withEmail("test@example.com")
-                .withUsername("sender")
-                .withProfile(Profile.builder()
-                        .withFirstName("John")
-                        .withLastName("Doe")
-                        .withDateOfBirth(LocalDate.of(1990, 1, 1))
-                        .withGender("Male")
-                        .withPostalCode("12345")
-                        .withPhoneNumber("1234567890")
-                        .withSportsOfPreference(
-                                List.of(new SportLevel("Basketball", "Intermediate"),
-                                        new SportLevel("Soccer", "Beginner")))
-                        .withRanking("100")
-                        .build())
-                        .withFriendList(senderFriendList)
-                .build());
+        String senderUsername = "sender";
+        Optional<User> sendUser = getUser(senderId, senderUsername, senderFriendList);
 
         String receiverId = "receiver";
-        Optional<User> receiverUser = Optional.of(User.builder()
-                .withId(receiverId)
-                .withEmail("test@example.com")
-                .withUsername("receiver")
-                .withProfile(Profile.builder()
-                        .withFirstName("John")
-                        .withLastName("Doe")
-                        .withDateOfBirth(LocalDate.of(1990, 1, 1))
-                        .withGender("Male")
-                        .withPostalCode("12345")
-                        .withPhoneNumber("1234567890")
-                        .withSportsOfPreference(
-                                List.of(new SportLevel("Basketball", "Intermediate"),
-                                        new SportLevel("Soccer", "Beginner")))
-                        .withRanking("100")
-                        .build())
-                        .withFriendList(receiverFriendList)
-                .build());
+        String receiverUsername = "receiver";
+        Optional<User> receiverUser = getUser(receiverId, receiverUsername, receiverFriendList);
 
         when(userRepository.findUserById(senderId)).thenReturn(sendUser);
         when(userRepository.findUserByUsername(receiverUser.get().getUsername())).thenReturn(receiverUser);
@@ -591,23 +569,8 @@ public class UserServiceTest {
     void sendFriendRequestShouldThrowUserSentFriendRequestToSelfException() {
         // Arrange
         String senderId = "sender";
-        Optional<User> sendUser = Optional.of(User.builder()
-                .withId(senderId)
-                .withEmail("test@example.com")
-                .withUsername("sender")
-                .withProfile(Profile.builder()
-                        .withFirstName("John")
-                        .withLastName("Doe")
-                        .withDateOfBirth(LocalDate.of(1990, 1, 1))
-                        .withGender("Male")
-                        .withPostalCode("12345")
-                        .withPhoneNumber("1234567890")
-                        .withSportsOfPreference(
-                                List.of(new SportLevel("Basketball", "Intermediate"),
-                                        new SportLevel("Soccer", "Beginner")))
-                        .withRanking("100")
-                        .build())
-                .build());
+        String sendUsername = "sender";
+        Optional<User> sendUser = getUser(senderId, sendUsername);
 
         when(userRepository.findUserById(senderId)).thenReturn(sendUser);
         when(userRepository.findUserByUsername(sendUser.get().getUsername())).thenReturn(sendUser);
@@ -619,6 +582,266 @@ public class UserServiceTest {
 
         // Assert
         assertEquals("409 CONFLICT \"Can't send friend request to self\"", exception.getMessage());
+    }
+
+    @Test
+    void updateFriendRequestACCEPTShouldReturnSuccess() {
+        // Arrange
+
+        List<Friend> userFriendList = new ArrayList<>();
+        userFriendList.add(new Friend("friend", FriendRequestStatusEnum.SENT));
+
+        List<Friend> friendFriendList = new ArrayList<>();
+        friendFriendList.add(new Friend("user", FriendRequestStatusEnum.RECEIVED));
+
+        String userId = "userID";
+        String username = "user";
+        User user = getUser(userId, username, userFriendList).orElseThrow();
+
+        String friendId = "friendID";
+        String friendUsername = "friend";
+        User friendUser = getUser(friendId, friendUsername, friendFriendList).orElseThrow();
+
+        UpdateFriendRequestRequest updateFriendRequestRequest = new UpdateFriendRequestRequest(friendUsername,
+                UpdateFriendRequestActionEnum.ACCEPT);
+
+        when(userRepository.findUserById(userId)).thenReturn(Optional.of(user));
+        when(userRepository.findUserByUsername(friendUser.getUsername())).thenReturn(Optional.of(friendUser));
+        when(friendRepository.findFriendById(any())).thenReturn(Optional.of(userFriendList.getFirst()));
+        lenient().when(userRepository.save(user)).thenReturn(user);
+        lenient().when(userRepository.save(friendUser)).thenReturn(friendUser);
+
+        // Act
+        UpdateFriendRequestResponse updateFriendRequestResponse = userService
+                .updateFriendRequest(userId, "requestID", updateFriendRequestRequest );
+
+        // Assert
+        assertEquals("User with username: " + user.getUsername()
+                + " accepted the friend request of user with username: " + friendUser.getUsername() + " successfully",
+                updateFriendRequestResponse.message());
+
+        assertEquals(FriendRequestStatusEnum.ACCEPTED, user.getFriendList().getFirst().getFriendRequestStatus());
+        assertEquals(FriendRequestStatusEnum.ACCEPTED, friendUser.getFriendList().getFirst().getFriendRequestStatus());
+    }
+
+    @Test
+    void updateFriendRequestDECLINEShouldReturnSuccess() {
+        // Arrange
+
+        List<Friend> userFriendList = new ArrayList<>();
+        userFriendList.add(new Friend("friend", FriendRequestStatusEnum.SENT));
+
+        List<Friend> friendFriendList = new ArrayList<>();
+        friendFriendList.add(new Friend("user", FriendRequestStatusEnum.RECEIVED));
+
+        String userId = "userID";
+        String username = "user";
+        User user = getUser(userId, username, userFriendList).orElseThrow();
+
+        String friendId = "friendID";
+        String friendUsername = "friend";
+        User friendUser = getUser(friendId, friendUsername, friendFriendList).orElseThrow();
+
+        UpdateFriendRequestRequest updateFriendRequestRequest = new UpdateFriendRequestRequest(friendUsername,
+                UpdateFriendRequestActionEnum.DECLINE);
+
+        when(userRepository.findUserById(userId)).thenReturn(Optional.of(user));
+        when(userRepository.findUserByUsername(friendUser.getUsername())).thenReturn(Optional.of(friendUser));
+        when(friendRepository.findFriendById(any())).thenReturn(Optional.of(userFriendList.getFirst()));
+        lenient().when(userRepository.save(user)).thenReturn(user);
+        lenient().when(userRepository.save(friendUser)).thenReturn(friendUser);
+
+        // Act
+        UpdateFriendRequestResponse updateFriendRequestResponse = userService
+                .updateFriendRequest(userId, "requestID", updateFriendRequestRequest );
+
+        // Assert
+        assertEquals("User with username: " + user.getUsername()
+                        + " declined the friend request of user with username: " + friendUser.getUsername() + " successfully",
+                updateFriendRequestResponse.message());
+
+        assertTrue(user.getFriendList().isEmpty());
+        assertTrue(friendUser.getFriendList().isEmpty());
+    }
+
+    @Test
+    void updateFriendRequestShouldThrowUserDoesNotExistExceptionOnUserID() {
+        // Arrange
+        String userId = new ObjectId().toHexString();
+
+        // Act
+        UserDoesNotExistException exception = assertThrows(UserDoesNotExistException.class, () ->
+                        userService.updateFriendRequest(userId, "requestId",
+                                new UpdateFriendRequestRequest("friendUsername",
+                                        UpdateFriendRequestActionEnum.ACCEPT)));
+
+        // Assert
+        assertEquals("404 NOT_FOUND \"User with identifier: " + userId + " does not exist.\"",
+                exception.getMessage());
+    }
+
+    @Test
+    void updateFriendRequestShouldThrowUserDoesNotExistExceptionOnFriendUsername() {
+        // Arrange
+        String userId = "userID";
+        String username = "user";
+        User user = getUser(userId, username).orElseThrow();
+        String friendUsername = new ObjectId().toHexString();
+
+        UpdateFriendRequestRequest updateFriendRequestRequest = new UpdateFriendRequestRequest(friendUsername,
+                UpdateFriendRequestActionEnum.DECLINE);
+
+        when(userRepository.findUserById(userId)).thenReturn(Optional.of(user));
+
+        // Act
+        UserDoesNotExistException exception = assertThrows(UserDoesNotExistException.class, () ->
+                userService.updateFriendRequest(userId, "requestId",
+                        updateFriendRequestRequest));
+
+        // Assert
+        assertEquals("404 NOT_FOUND \"User with identifier: " + friendUsername + " does not exist.\"",
+                exception.getMessage());
+    }
+
+    @Test
+    void updateFriendRequestShouldThrowFriendDoesNotExistException() {
+        // Arrange
+        String requestId = new ObjectId().toHexString();
+        String userId = "userID";
+        String username = "user";
+        User user = getUser(userId, username).orElseThrow();
+
+        String friendId = "friendID";
+        String friendUsername = "friend";
+        User friendUser = getUser(friendId, friendUsername).orElseThrow();
+
+        UpdateFriendRequestRequest updateFriendRequestRequest = new UpdateFriendRequestRequest(friendUsername,
+                UpdateFriendRequestActionEnum.DECLINE);
+
+        when(userRepository.findUserById(userId)).thenReturn(Optional.of(user));
+        when(userRepository.findUserByUsername(friendUser.getUsername())).thenReturn(Optional.of(friendUser));
+
+        // Act
+        FriendDoesNotExistException exception = assertThrows(FriendDoesNotExistException.class, () ->
+                userService.updateFriendRequest(userId, requestId,
+                        updateFriendRequestRequest));
+
+        // Assert
+        assertEquals("404 NOT_FOUND \"Friend with identifier: " + requestId + " does not exist.\"",
+                exception.getMessage());
+    }
+
+    @Test
+    void updateFriendRequestShouldThrowGivenFriendUsernameDoesNotMatchFriendFoundByIdException() {
+        // Arrange
+        String requestId = new ObjectId().toHexString();
+        List<Friend> userFriendList = new ArrayList<>();
+        userFriendList.add(new Friend("friend", FriendRequestStatusEnum.SENT));
+
+        List<Friend> friendFriendList = new ArrayList<>();
+        friendFriendList.add(new Friend("user", FriendRequestStatusEnum.RECEIVED));
+
+        String userId = "userID";
+        String username = "user";
+        User user = getUser(userId, username, userFriendList).orElseThrow();
+
+        String friendId = "friendID";
+        String friendUsername = "friend";
+        User friendUser = getUser(friendId, friendUsername, friendFriendList).orElseThrow();
+
+        String wrongUserId = "wrongUserId";
+        String wrongUserUsername = "wrongUser";
+        User wrongUser = getUser(wrongUserId, wrongUserUsername).orElseThrow();
+
+        UpdateFriendRequestRequest updateFriendRequestRequest = new UpdateFriendRequestRequest(wrongUser.getUsername(),
+                UpdateFriendRequestActionEnum.ACCEPT);
+
+        when(userRepository.findUserById(userId)).thenReturn(Optional.of(user));
+        when(userRepository.findUserByUsername(wrongUser.getUsername())).thenReturn(Optional.of(wrongUser));
+        when(friendRepository.findFriendById(any())).thenReturn(Optional.of(userFriendList.getFirst()));
+
+        // Act
+        GivenFriendUsernameDoesNotMatchFriendFoundByIdException exception =
+                assertThrows(GivenFriendUsernameDoesNotMatchFriendFoundByIdException.class, () ->
+                userService.updateFriendRequest(userId, requestId ,
+                        updateFriendRequestRequest));
+
+        // Assert
+        assertEquals("409 CONFLICT \"Given friend with the username: "
+                + wrongUser.getUsername() + " does not match the friend found with the given request id: "
+                + requestId + "\"", exception.getMessage());
+    }
+
+    @Test
+    void updateFriendRequestShouldThrowFriendNotFoundInFriendListExceptionFromIsFriendFound1() {
+        // Arrange
+        List<Friend> userFriendList = new ArrayList<>();
+        Friend userFriend = new Friend("friend", FriendRequestStatusEnum.SENT);
+
+        List<Friend> friendFriendList = new ArrayList<>();
+        friendFriendList.add(new Friend("user", FriendRequestStatusEnum.RECEIVED));
+
+        String userId = "userID";
+        String username = "user";
+        User user = getUser(userId, username, userFriendList).orElseThrow();
+
+        String friendId = "friendID";
+        String friendUsername = "friend";
+        User friendUser = getUser(friendId, friendUsername, friendFriendList).orElseThrow();
+
+        UpdateFriendRequestRequest updateFriendRequestRequest = new UpdateFriendRequestRequest(friendUsername,
+                UpdateFriendRequestActionEnum.DECLINE);
+
+        when(userRepository.findUserById(userId)).thenReturn(Optional.of(user));
+        when(userRepository.findUserByUsername(friendUser.getUsername())).thenReturn(Optional.of(friendUser));
+        when(friendRepository.findFriendById(any())).thenReturn(Optional.of(userFriend));
+        lenient().when(userRepository.save(user)).thenReturn(user);
+        lenient().when(userRepository.save(friendUser)).thenReturn(friendUser);
+
+        // Act
+        FriendNotFoundInFriendListException exception = assertThrows(FriendNotFoundInFriendListException.class, () ->
+                userService.updateFriendRequest(userId, "requestId", updateFriendRequestRequest));
+
+        // Assert
+        assertEquals("404 NOT_FOUND \"User with identifier: "
+                + user.getUsername() + " does not have friend with identifier: "
+                + friendUser.getUsername() + " in their friend list.\"", exception.getMessage());
+    }
+
+    @Test
+    void updateFriendRequestShouldThrowFriendNotFoundInFriendListExceptionFromIsFriendFound2() {
+        // Arrange
+        List<Friend> userFriendList = new ArrayList<>();
+        Friend userFriend = new Friend("friend", FriendRequestStatusEnum.SENT);
+        userFriendList.add(userFriend);
+
+        List<Friend> friendFriendList = new ArrayList<>();
+
+        String userId = "userID";
+        String username = "user";
+        User user = getUser(userId, username, userFriendList).orElseThrow();
+
+        String friendId = "friendID";
+        String friendUsername = "friend";
+        User friendUser = getUser(friendId, friendUsername, friendFriendList).orElseThrow();
+
+        UpdateFriendRequestRequest updateFriendRequestRequest = new UpdateFriendRequestRequest(friendUsername,
+                UpdateFriendRequestActionEnum.DECLINE);
+
+        when(userRepository.findUserById(userId)).thenReturn(Optional.of(user));
+        when(userRepository.findUserByUsername(friendUser.getUsername())).thenReturn(Optional.of(friendUser));
+        when(friendRepository.findFriendById(any())).thenReturn(Optional.of(userFriend));
+        lenient().when(userRepository.save(user)).thenReturn(user);
+        lenient().when(userRepository.save(friendUser)).thenReturn(friendUser);
+
+        // Act
+        FriendNotFoundInFriendListException exception = assertThrows(FriendNotFoundInFriendListException.class, () ->
+                userService.updateFriendRequest(userId, "requestId", updateFriendRequestRequest));
+
+        // Assert
+        assertEquals("404 NOT_FOUND \"User with identifier: "
+                + friendUser.getUsername() + " does not have friend with identifier: "
+                + user.getUsername() + " in their friend list.\"", exception.getMessage());
     }
 
     @Test

--- a/Microservices/user-service/src/test/java/app/sportahub/userservice/service/user/UserServiceTest.java
+++ b/Microservices/user-service/src/test/java/app/sportahub/userservice/service/user/UserServiceTest.java
@@ -2,6 +2,7 @@ package app.sportahub.userservice.service.user;
 
 import app.sportahub.userservice.client.KeycloakApiClient;
 import app.sportahub.userservice.dto.request.user.*;
+import app.sportahub.userservice.dto.request.user.friend.FriendRequestRequest;
 import app.sportahub.userservice.dto.request.user.keycloak.KeycloakRequest;
 import app.sportahub.userservice.dto.response.user.friend.FriendRequestResponse;
 import app.sportahub.userservice.dto.response.user.ProfileResponse;
@@ -11,6 +12,8 @@ import app.sportahub.userservice.dto.response.user.friend.ViewFriendRequestsResp
 import app.sportahub.userservice.enums.user.FriendRequestStatusEnum;
 import app.sportahub.userservice.exception.user.*;
 import app.sportahub.userservice.exception.user.badge.UserAlreadyAssignedBadgeByThisGiverException;
+import app.sportahub.userservice.exception.user.friend.UserAlreadyInFriendListException;
+import app.sportahub.userservice.exception.user.friend.UserSentFriendRequestToSelfException;
 import app.sportahub.userservice.exception.user.friend.InvalidFriendRequestStatusTypeException;
 import app.sportahub.userservice.exception.user.friend.UserAlreadyInFriendListException;
 import app.sportahub.userservice.exception.user.friend.UserSentFriendRequestToSelfException;
@@ -18,6 +21,7 @@ import app.sportahub.userservice.mapper.user.ProfileMapper;
 import app.sportahub.userservice.mapper.user.UserMapper;
 import app.sportahub.userservice.model.user.*;
 import app.sportahub.userservice.repository.BadgeRepository;
+import app.sportahub.userservice.repository.FriendRepository;
 import app.sportahub.userservice.repository.UserRepository;
 import org.bson.types.ObjectId;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,6 +55,9 @@ public class UserServiceTest {
     private BadgeRepository badgeRepository;
 
     @Mock
+    private FriendRepository friendRepository;
+
+    @Mock
     private KeycloakApiClient keycloakApiClient;
 
     private final UserMapper userMapper = Mappers.getMapper(UserMapper.class);
@@ -62,7 +69,7 @@ public class UserServiceTest {
     @BeforeEach
     void setUp() {
         userService = new UserServiceImpl(userRepository, badgeRepository,
-                keycloakApiClient, userMapper, profileMapper);
+                keycloakApiClient, userMapper, profileMapper, friendRepository);
     }
 
     private UserRequest getUserRequest() {


### PR DESCRIPTION
This PR implements an endpoint to accept or decline friend requests.

It also refactors the Friend object to now hold an id.

The userService.updateFriendRequest method takes in a given userId, requestId, and an UpdateFriendRequestRequest consisting of the username of the friend whose request you want to modify, as well as an action represented by an enum with two possible inputs; ACCEPT or DECLINE.

It checks if the inputs are valid and updates the affected users' friendlists by either modifying the status in the case of an ACCEPT action, or removing the friend from the friendlist if the given action is DECLINE.

Unit tests were written to validate successful and unsuccessful calls to the method.

