### PR TITLE
GH-232: [fix] Assign default participantAttendStatus when a player joins an event

### DIFF
--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/controller/EventController.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/controller/EventController.java
@@ -2,6 +2,7 @@ package app.sportahub.eventservice.controller;
 
 import app.sportahub.eventservice.dto.request.EventRequest;
 import app.sportahub.eventservice.dto.response.EventResponse;
+import app.sportahub.eventservice.dto.response.ParticipantResponse;
 import app.sportahub.eventservice.service.event.EventService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -66,7 +67,7 @@ public class EventController {
     @PostMapping("/{id}/join")
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "Join an event", description = "Enables a user to join an event, provided there are available slots.")
-    public void joinEvent(@PathVariable String id, @RequestParam String userId) {
-        eventService.joinEvent(id, userId);
+    public ParticipantResponse joinEvent(@PathVariable String id, @RequestParam String userId) {
+        return eventService.joinEvent(id, userId);
     }
 }

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/dto/response/EventResponse.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/dto/response/EventResponse.java
@@ -1,9 +1,9 @@
 package app.sportahub.eventservice.dto.response;
 
 import app.sportahub.eventservice.enums.SkillLevelEnum;
-import app.sportahub.eventservice.model.event.participant.Participant;
 import app.sportahub.eventservice.model.event.Team;
 import com.fasterxml.jackson.annotation.JsonInclude;
+
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.EnumSet;
@@ -11,8 +11,9 @@ import java.util.List;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record EventResponse(String id, String eventName, String eventType, String sportType,
-                            LocationResponse locationResponse, LocalDate date, LocalTime startTime, LocalTime endTime, String duration, Integer maxParticipants,
-                            List<Participant> participants, String createdBy, List<Team> teams, String cutOffTime,
-                            String description, Boolean isPrivate, List<String> whitelistedUsers,
+                            LocationResponse locationResponse, LocalDate date, LocalTime startTime, LocalTime endTime,
+                            String duration, Integer maxParticipants, List<ParticipantResponse> participants,
+                            String createdBy, List<Team> teams, String cutOffTime, String description,
+                            Boolean isPrivate, List<String> whitelistedUsers,
                             EnumSet<SkillLevelEnum> requiredSkillLevel) {
 }

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/dto/response/ParticipantResponse.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/dto/response/ParticipantResponse.java
@@ -1,0 +1,20 @@
+package app.sportahub.eventservice.dto.response;
+
+import app.sportahub.eventservice.model.event.participant.ParticipantAttendStatus;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.constraints.NotBlank;
+
+import java.time.LocalDate;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ParticipantResponse(
+        @NotBlank(message = "Valid user id must be provided")
+        String userId,
+
+        @NotBlank(message = "Attend status must be provided")
+        ParticipantAttendStatus attendStatus,
+
+        @NotBlank(message = "Date user joined must be provided")
+        LocalDate joinedOn
+) {
+}

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/mapper/event/EventMapper.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/mapper/event/EventMapper.java
@@ -16,6 +16,7 @@ public interface EventMapper {
     @Mapping(target = "locationResponse", source = "location")
     EventResponse eventToEventResponse(Event event);
 
+    @Mapping(target = "id", ignore = true)
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
     void patchEventFromRequest(EventRequest eventRequest, @MappingTarget Event event);
 }

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/service/event/EventService.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/service/event/EventService.java
@@ -2,8 +2,7 @@ package app.sportahub.eventservice.service.event;
 
 import app.sportahub.eventservice.dto.request.EventRequest;
 import app.sportahub.eventservice.dto.response.EventResponse;
-
-import java.util.Map;
+import app.sportahub.eventservice.dto.response.ParticipantResponse;
 
 public interface EventService {
 
@@ -17,5 +16,5 @@ public interface EventService {
 
     void deleteEvent(String id);
 
-    void joinEvent(String id, String userId);
+    ParticipantResponse joinEvent(String id, String userId);
 }

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/service/event/EventServiceImpl.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/service/event/EventServiceImpl.java
@@ -2,10 +2,12 @@ package app.sportahub.eventservice.service.event;
 
 import app.sportahub.eventservice.dto.request.EventRequest;
 import app.sportahub.eventservice.dto.response.EventResponse;
+import app.sportahub.eventservice.dto.response.ParticipantResponse;
 import app.sportahub.eventservice.exception.event.*;
 import app.sportahub.eventservice.mapper.event.EventMapper;
 import app.sportahub.eventservice.model.event.Event;
 import app.sportahub.eventservice.model.event.participant.Participant;
+import app.sportahub.eventservice.model.event.participant.ParticipantAttendStatus;
 import app.sportahub.eventservice.repository.EventRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -71,7 +73,7 @@ public class EventServiceImpl implements EventService {
      */
     @Override
     public EventResponse updateEvent(String id, EventRequest eventRequest) {
-        Event event = eventRepository.findById(id)
+        eventRepository.findById(id)
                 .orElseThrow(() -> new EventDoesNotExistException(id));
 
         Event updatedEvent = eventMapper.eventRequestToEvent(eventRequest)
@@ -149,7 +151,7 @@ public class EventServiceImpl implements EventService {
      * @throws UserAlreadyParticipantException    if the user is already participating in the event
      */
     @Override
-    public void joinEvent(String id, String userId) {
+    public ParticipantResponse joinEvent(String id, String userId) {
         Event event = eventRepository.findById(id)
                 .orElseThrow(() -> new EventDoesNotExistException(id));
 
@@ -175,11 +177,14 @@ public class EventServiceImpl implements EventService {
 
         Participant participant = Participant.builder()
                 .withUserId(userId)
+                .withAttendStatus(ParticipantAttendStatus.JOINED)
                 .withJoinedOn(LocalDateTime.now().toLocalDate())
                 .build();
 
         event.getParticipants().add(participant);
         eventRepository.save(event);
         log.info("EventServiceImpl::joinEvent: User with id:{} joined event with id:{}", userId, id);
+        return new ParticipantResponse(participant.getUserId(), participant.getAttendStatus(),
+                participant.getJoinedOn());
     }
 }

--- a/Microservices/event-service/src/test/java/app/sportahub/eventservice/service/event/EventServiceTest.java
+++ b/Microservices/event-service/src/test/java/app/sportahub/eventservice/service/event/EventServiceTest.java
@@ -1,9 +1,6 @@
 package app.sportahub.eventservice.service.event;
 
-import app.sportahub.eventservice.dto.request.EventRequest;
-import app.sportahub.eventservice.dto.request.LocationRequest;
-import app.sportahub.eventservice.dto.request.ParticipantRequest;
-import app.sportahub.eventservice.dto.request.TeamRequest;
+import app.sportahub.eventservice.dto.request.*;
 import app.sportahub.eventservice.dto.response.EventResponse;
 import app.sportahub.eventservice.enums.SkillLevelEnum;
 import app.sportahub.eventservice.exception.event.*;
@@ -134,7 +131,7 @@ public class EventServiceTest {
         assertEquals(eventRequest.date(), result.date());
         assertEquals(eventRequest.maxParticipants(), result.maxParticipants());
         assert eventRequest.participants() != null;
-        assertEquals(eventRequest.participants().getFirst().userId(), result.participants().getFirst().getUserId());
+        assertEquals(eventRequest.participants().getFirst().userId(), result.participants().getFirst().userId());
         assertEquals(eventRequest.createdBy(), result.createdBy());
         assert eventRequest.teams() != null;
         assertEquals(eventRequest.teams().getFirst().teamId(), result.teams().getFirst().getTeamId());
@@ -199,8 +196,7 @@ public class EventServiceTest {
         assertEquals(eventRequest.date(), result.date());
         assertEquals(eventRequest.maxParticipants(), result.maxParticipants());
         assert eventRequest.participants() != null;
-        assertEquals(eventRequest.participants().getFirst().userId(), result.participants().getFirst().getUserId());
-        assertEquals(eventRequest.participants().getFirst().attendStatus(), result.participants().getFirst().getAttendStatus());
+        assertEquals(eventRequest.participants().getFirst().userId(), result.participants().getFirst().userId());
         assertEquals(eventRequest.createdBy(), result.createdBy());
         assert eventRequest.teams() != null;
         assertEquals(eventRequest.teams().getFirst().teamId(), result.teams().getFirst().getTeamId());
@@ -363,6 +359,7 @@ public class EventServiceTest {
         // Act & Assert
         eventService.joinEvent(testId, testUserId);
 
+        assertEquals(ParticipantAttendStatus.JOINED, event.getParticipants().getFirst().getAttendStatus());
         verify(eventRepository, times(1)).findById(testId);
         verify(eventRepository, times(1)).save(event);
     }
@@ -445,6 +442,7 @@ public class EventServiceTest {
         eventService.joinEvent(testId, testUserId);
 
         // Assert
+        assertEquals(ParticipantAttendStatus.JOINED, privateEvent.getParticipants().getFirst().getAttendStatus());
         verify(eventRepository, times(1)).save(any(Event.class));
     }
 


### PR DESCRIPTION
### Description
This pull request resolves an issue where the `participantAttendStatus` field was not being correctly set when a user joined an event. The following changes have been made:
- Added a `ParticipantResponse` DTO to include `participantAttendStatus`, `userId`, and `joinedOn`.
- Updated the `joinEvent` method to return a `ParticipantResponse` after successfully adding the participant.
- Refactored the `EventService` and its implementation to handle the assignment of the default `participantAttendStatus`.
- Adjusted the mapper to include the new `ParticipantResponse` structure.
- Added a default status for new participants.

### Changes
- Updated `EventService` interface and implementation.
- Modified `joinEvent` in `EventController` to return the participant response.
- Added a new DTO `ParticipantResponse` for better encapsulation.
- Included the default `participantAttendStatus` logic in the `EventServiceImpl`.

### Closing Keyword
Closes #232
