### PR TITLE
GH-208: [feat] Added functionality to delete users

### DIFF
--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/controller/user/UserController.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/controller/user/UserController.java
@@ -76,6 +76,14 @@ public class UserController {
         return userService.getUserBadges(userId);
     }
 
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(summary = "Delete user by ID",
+            description = "Deletes a user by their unique identifier.")
+    public void deleteUserById(@PathVariable String id) {
+        userService.deleteUserById(id);
+    }
+
     @PostMapping("/{userId}/friends/requests")
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "Send a friend request to a user",

--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/service/user/UserService.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/service/user/UserService.java
@@ -30,6 +30,8 @@ public interface UserService {
 
     List<BadgeWithCountResponse> getUserBadges(String userId);
 
+    void deleteUserById(String id);
+
     FriendRequestResponse sendFriendRequest(String userId, FriendRequestRequest friendRequestRequest);
 
     List<ViewFriendRequestsResponse> getFriendRequests(String userId, List<FriendRequestStatusEnum> typeList);


### PR DESCRIPTION
**Description:**  
This PR introduces the ability to delete users by their unique identifier. The following changes were made:  
- Added a new `DELETE user/{id}` endpoint in `UserController`.  
- Implemented `deleteUserById` method in `UserService` and `UserServiceImpl`.  
- Included error handling for cases where the user does not exist or when the Keycloak deletion fails.  
- Added unit tests to cover successful deletion, user not found, and Keycloak communication errors.  

Closes GH-208.