### PR TITLE
GH-202: Feature/issue 202/create event card on profile page of user

### DIFF
--- a/ClientApp/app/(tabs)/profile/index.tsx
+++ b/ClientApp/app/(tabs)/profile/index.tsx
@@ -6,6 +6,7 @@ import { useRouter} from 'expo-router';
 import { UserState } from '@/types/user';
 import { calculateAge } from '@/utils/helpers/ageOfUser';
 import { useSelector } from 'react-redux';
+import EventListProfilePage from '@/components/Event/EventListProfilePage';
 
 const screenHeight = Dimensions.get('window').height;
 const maxHeight = screenHeight * 0.5
@@ -14,7 +15,7 @@ const maxHeight = screenHeight * 0.5
 const ActivityTab = () => (
     //TODO fix the overlap between the two scroll views when the events are scolled up 
     <View className="p-4 bg-white">
-        {/* Horizontal Scroll for Badges hard coded*/}
+        {/* Horizontal Scroll for Badges hard coded */}
         <ScrollView horizontal showsHorizontalScrollIndicator={false}>
             <View className="flex-row gap-x-4">
                 <View className="w-20 h-20 bg-gray-700 rounded-full" />
@@ -28,16 +29,9 @@ const ActivityTab = () => (
             </View>
         </ScrollView>
 
-        {/* Vertical Scroll for Event Cards hard coded */}
-        <ScrollView className=" pt-3 space-y-4" style={{ maxHeight}}>
-            {Array.from({ length: 6 }).map((_, index) => (
-                <View key={index} className="mt-4 p-4 rounded-lg" style={{ backgroundColor: '#0C9E04' }}>
-                    <Text className="text-xl font-bold text-black">EVENT {index + 1}</Text>
-                    <Text className="text-gray-800 text-sm">Location</Text>
-                    <Text className="text-gray-800 text-xs mt-1">Date</Text>
-                </View>
-            ))}
-        </ScrollView>
+        <View>
+            <EventListProfilePage />
+        </View>
     </View>
 );
 
@@ -116,7 +110,7 @@ const ProfilePage: React.FC = () => {
     const routes = [
         { key: 'activity', title: 'Activity', testID: 'Activity' },
         { key: 'friends', title: 'Friends', testID: 'Friends' },
-        { key: 'about', title: 'About', testID: 'About'},
+        { key: 'about', title: 'My Events', testID: 'About'},
     ];
     const scenes = {
         activity: <ActivityTab />,
@@ -127,8 +121,7 @@ const ProfilePage: React.FC = () => {
     return (
         <SafeAreaView className="flex-1 bg-white pt-6">
             {/* Top Header with Edit Button */}
-            <View className="flex-row justify-center items-center p-4 relative">
-                <Text className="text-2xl font-bold text-black">Profile</Text>
+            <View className="flex-row justify-center items-center p-3 relative">
                 <TouchableOpacity
                  onPress={() => router.push('/editProfile')}
                  className="absolute left-4" 
@@ -137,7 +130,7 @@ const ProfilePage: React.FC = () => {
                 </TouchableOpacity>
              <TouchableOpacity 
                     onPress={() => router.push('/(tabs)/profile/(settings)/settingsPage')} 
-                    className="absolute right-4" // Position Edit button in top-right
+                    className="absolute right-4"
                 >
                     <Icon name="settings-outline" size={24} color="black" />
                 </TouchableOpacity>
@@ -150,7 +143,7 @@ const ProfilePage: React.FC = () => {
                     source={{ uri: 'https://example.com/profile-image.png' }}
                     defaultSource={require('@/assets/images/Unknown.jpg')}
                 />
-                <Text testID="firstName" className="text-2xl font-bold text-black mt-4">
+                <Text testID="firstName" className="text-2xl font-bold text-black mt-2">
                     {user?.profile.firstName} {user?.profile.lastName}
                 </Text>
                 <Text className="text-sm text-gray-500">

--- a/ClientApp/components/Event/EventCard.tsx
+++ b/ClientApp/components/Event/EventCard.tsx
@@ -16,18 +16,20 @@ interface EventCardProps {
   showLocation?: boolean;
   showSportType?: boolean;
   showTimeLeft?: boolean;
+  isForProfile?: boolean;
 }
 
 const EventCard: React.FC<EventCardProps> = ({
   event,
   onPress,
-  showSkillTags = true, 
-  showCapacity = true, 
-  showDescription = true,
+  isForProfile = false,
+  showSkillTags = isForProfile? false: true, 
+  showCapacity = isForProfile? false: true, 
+  showDescription = isForProfile? false: true,
   showDetailPreview = true,
   showDate = true,
-  showLocation = true,
-  showTimeLeft = true,
+  showLocation = isForProfile? false: true,
+  showTimeLeft = isForProfile? false: true,
   showSportType = true,
 }) => {
 
@@ -55,6 +57,8 @@ const timeLeftshown = "";
 
 // Ensure both currentTime and cutoffTime are valid
 let timeLeftShown = "";
+let eventStarted = false;
+let canJoin = true;
 
 if (!isNaN(cutoffTime.getTime())) {
   const timeLeft = cutoffTime.getTime() - currentTime.getTime();
@@ -75,16 +79,32 @@ if (!isNaN(cutoffTime.getTime())) {
       timeLeftShown = `${weeksLeft} week${weeksLeft > 1 ? "s" : ""}`;
     }
   } else {
-    return null  }
+    if (!isForProfile) return null;
+    canJoin = false;
+    if(currentTime.getTime() > new Date(event.cutOffTime).getTime()) {
+      eventStarted = true;
+    }
+  }
 } else {
   console.error("Invalid cutoff time format.");
 }
 
+// Dynamic styling for the card
+const dynamicCardStyle = {
+  backgroundColor: (eventStarted && isForProfile)? "#B9B9B9" : "#ffffff", // Light red for expired, white for active
+  borderColor: canJoin ? "#f5c2c7" : "#cccccc", // Red border for expired, grey for active
+};
+
+const dynamicTimeLeftStyle = {
+  color: canJoin ? "#dc3545" : "#000000", // Red text for expired, black for active
+};
+
 return (
-  <TouchableOpacity style={styles.card} onPress={() => onPress(event.id)}>
+  <TouchableOpacity style={[styles.card, dynamicCardStyle]} onPress={() => onPress(event.id)}>
     <Text style={styles.eventName}>{event.eventName}</Text> 
     {showDetailPreview && 
     <Text style={styles.eventDetails}>
+      {/*TODO - Add distance calculation after backend does it*/}
       {showSportType ? `${event.sportType} - X km away` : `X km away`}
       </Text>}
     

--- a/ClientApp/components/Event/EventListProfilePage.tsx
+++ b/ClientApp/components/Event/EventListProfilePage.tsx
@@ -1,0 +1,398 @@
+import React, { useRef } from 'react';
+import { FlatList, View, StyleSheet, Alert, Animated, RefreshControl, Text} from 'react-native';
+import EventCard from './EventCard';
+import { Event } from '@/types/event';
+
+// FIXME Sample event data until we can fetch from an API
+const events: Event[] = [
+  {
+    id: '67806df20ba257b189946ff25',
+    eventName: 'Victory Sprint',
+    eventType: 'Private',
+    sportType: 'Football',
+    locationResponse: {
+      name: 'Central Park',
+      streetNumber: '59',
+      streetName: 'Central Park W',
+      city: 'New York',
+      province: 'NY',
+      country: 'USA',
+      postalCode: '10023',
+      phoneNumber: '212-310-6600',
+      latitude: '40.785091',
+      longitude: '-73.968285',
+    },
+    date: '2023-06-15',
+    maxParticipants: 50,
+    participants: [],
+    createdBy: 'user123',
+    teams: [],
+    cutOffTime: '2023-06-14T22:00:00',
+    description: 'Join us for a thrilling sprint event in Central Park. A challenge for both beginners and intermediate runners.',
+    isPrivate: false,
+    whitelistedUsers: [],
+    requiredSkillLevel: ['BEGINNER', 'INTERMEDIATE', 'ADVANCED'],
+  },
+  {
+    id: '67806f20ba257b1899v46ff25',
+    eventName: 'Lovely Sprint',
+    eventType: 'Private',
+    sportType: 'Basketball',
+    locationResponse: {
+      name: 'Central Park',
+      streetNumber: '59',
+      streetName: 'Central Park W',
+      city: 'New York',
+      province: 'NY',
+      country: 'USA',
+      postalCode: '10023',
+      phoneNumber: '212-310-6600',
+      latitude: '40.785091',
+      longitude: '-73.968285',
+    },
+    date: '2025-06-15',
+    maxParticipants: 50,
+    participants: [],
+    createdBy: 'user123',
+    teams: [],
+    cutOffTime: '2025-06-14T22:00:00',
+    description: 'Join us for a thrilling sprint event in Central Park. A challenge for both beginners and intermediate runners.',
+    isPrivate: false,
+    whitelistedUsers: [],
+    requiredSkillLevel: ['BEGINNER', 'INTERMEDIATE', 'ADVANCED'],
+  },
+  {
+    id: '6780s6f20ba257b189946ff25',
+    eventName: '1v1 For Money',
+    eventType: 'Public',
+    sportType: 'Baseball',
+    locationResponse: {
+      name: 'Central Park',
+      streetNumber: '59',
+      streetName: 'Central Park W',
+      city: 'New York',
+      province: 'NY',
+      country: 'USA',
+      postalCode: '10023',
+      phoneNumber: '212-310-6600',
+      latitude: '40.785091',
+      longitude: '-73.968285',
+    },
+    date: '2025-06-15',
+    maxParticipants: 50,
+    participants: [],
+    createdBy: 'user123',
+    teams: [],
+    cutOffTime: '2025-06-13T22:00:00',
+    description: 'Join us for a thrilling sprint event in Central Park. A challenge for both beginners and intermediate runners.',
+    isPrivate: false,
+    whitelistedUsers: [],
+    requiredSkillLevel: ['BEGINNER', 'INTERMEDIATE', 'ADVANCED'],
+  },
+  {
+    id: '67806f20ba257b189946aff25',
+    eventName: 'Victory Sprint',
+    eventType: 'Private',
+    sportType: 'Hockey',
+    locationResponse: {
+      name: 'Central Park',
+      streetNumber: '59',
+      streetName: 'Central Park W',
+      city: 'New York',
+      province: 'NY',
+      country: 'USA',
+      postalCode: '10023',
+      phoneNumber: '212-310-6600',
+      latitude: '40.785091',
+      longitude: '-73.968285',
+    },
+    date: '2024-01-16',
+    maxParticipants: 50,
+    participants: [],
+    createdBy: 'user123',
+    teams: [],
+    cutOffTime: '2024-1-15T22:00:00',
+    description: 'Join us for a thrilling sprint event in Central Park. A challenge for both beginners and intermediate runners.',
+    isPrivate: false,
+    whitelistedUsers: [],
+    requiredSkillLevel: ['BEGINNER', 'INTERMEDIATE', 'ADVANCED'],
+  },
+  {
+    id: '67806f20ba257b189946ff25',
+    eventName: 'Victory Sprint',
+    eventType: 'Public',
+    sportType: 'Soccer',
+    locationResponse: {
+      name: 'Central Park',
+      streetNumber: '59',
+      streetName: 'Central Park W',
+      city: 'New York',
+      province: 'NY',
+      country: 'USA',
+      postalCode: '10023',
+      phoneNumber: '212-310-6600',
+      latitude: '40.785091',
+      longitude: '-73.968285',
+    },
+    date: '2022-01-14',
+    maxParticipants: 50,
+    participants: [],
+    createdBy: 'user123',
+    teams: [],
+    cutOffTime: '2022-1-15T22:00:00',
+    description: 'Join us for a thrilling sprint event in Central Park. A challenge for both beginners and intermediate runners.',
+    isPrivate: false,
+    whitelistedUsers: [],
+    requiredSkillLevel: ['BEGINNER', 'INTERMEDIATE', 'ADVANCED'],
+  },
+  {
+    id: '67806f20ba257b189946ff23',
+    eventName: 'Final Push',
+    eventType: 'Public',
+    sportType: 'Golf',
+    locationResponse: {
+      name: 'Cycling Arena',
+      streetNumber: '25',
+      streetName: 'Cycle Lane',
+      city: 'Austin',
+      province: 'TX',
+      country: 'USA',
+      postalCode: '73301',
+      phoneNumber: '512-555-1234',
+      latitude: '30.267153',
+      longitude: '-97.743057',
+    },
+    date: '2025-07-20',
+    maxParticipants: 30,
+    participants: [],
+    createdBy: 'user456',
+    teams: [],
+    cutOffTime: '2025-2-11T01:28:00',
+    description: 'An exciting cycling event for beginners and advanced participants. Push yourself to the limit!',
+    isPrivate: false,
+    whitelistedUsers: [],
+    requiredSkillLevel: ['BEGINNER', 'ADVANCED'],
+  },
+  {
+    id: '67806f20bda257b189946ff23',
+    eventName: 'Fast Break',
+    eventType: 'Private',
+    sportType: 'Tennis',
+    locationResponse: {
+      name: 'Downtown Court',
+      streetNumber: '300',
+      streetName: 'Main St',
+      city: 'Chicago',
+      province: 'IL',
+      country: 'USA',
+      postalCode: '60601',
+      phoneNumber: '312-555-5678',
+      latitude: '41.878113',
+      longitude: '-87.629799',
+    },
+    date: '2022-08-05',
+    maxParticipants: 20,
+    participants: [],
+    createdBy: 'user789',
+    teams: [],
+    cutOffTime: '2022-08-04T19:30:00',
+    description: 'Experience the thrill of a fast-paced basketball match in the heart of Chicago. For advanced players only.',
+    isPrivate: false,
+    whitelistedUsers: [],
+    requiredSkillLevel: ['ADVANCED'],
+  },
+  {
+    id: '67806f20ba257b1899er6ff23',
+    eventName: 'Joud Event',
+    eventType: 'Private',
+    sportType: 'Hiking',
+    locationResponse: {
+      name: 'Soccer Field',
+      streetNumber: '15',
+      streetName: 'Elm St',
+      city: 'Los Angeles',
+      province: 'CA',
+      country: 'USA',
+      postalCode: '90001',
+      phoneNumber: '323-555-8765',
+      latitude: '34.052235',
+      longitude: '-118.243683',
+    },
+    date: '2024-09-10',
+    maxParticipants: 25,
+    participants: [],
+    createdBy: 'user321',
+    teams: [],
+    cutOffTime: '2024-09-009T19:30:00',
+    description: 'A friendly soccer match open to beginners. Have fun and improve your skills on the field!',
+    isPrivate: false,
+    whitelistedUsers: [],
+    requiredSkillLevel: ['BEGINNER'],
+  },
+  {
+    id: '67806f20bda257b18f9946ff23',
+    eventName: 'Fast Break',
+    eventType: 'Public',
+    sportType: 'Boxing',
+    locationResponse: {
+      name: 'Downtown Court',
+      streetNumber: '300',
+      streetName: 'Main St',
+      city: 'Chicago',
+      province: 'IL',
+      country: 'USA',
+      postalCode: '60601',
+      phoneNumber: '312-555-5678',
+      latitude: '41.878113',
+      longitude: '-87.629799',
+    },
+    date: '2021-08-05',
+    maxParticipants: 20,
+    participants: [],
+    createdBy: 'user789',
+    teams: [],
+    cutOffTime: '2021-7-025T19:30:00',
+    description: 'Experience the thrill of a fast-paced basketball match in the heart of Chicago. For advanced players only.',
+    isPrivate: false,
+    whitelistedUsers: [],
+    requiredSkillLevel: ['ADVANCED'],
+  },
+  {
+    id: '67806f20bdda257b18f9946ff23',
+    eventName: 'Fast Break',
+    eventType: 'Public',
+    sportType: 'Cycling',
+    locationResponse: {
+      name: 'Downtown Court',
+      streetNumber: '300',
+      streetName: 'Main St',
+      city: 'Chicago',
+      province: 'IL',
+      country: 'USA',
+      postalCode: '60601',
+      phoneNumber: '312-555-5678',
+      latitude: '41.878113',
+      longitude: '-87.629799',
+    },
+    date: '2025-08-05',
+    maxParticipants: 20,
+    participants: [],
+    createdBy: 'user789',
+    teams: [],
+    cutOffTime: '2025-1-025T19:30:00',
+    description: 'Experience the thrill of a fast-paced basketball match in the heart of Chicago. For advanced players only.',
+    isPrivate: false,
+    whitelistedUsers: [],
+    requiredSkillLevel: ['ADVANCED'],
+  },
+  {
+    id: '67806f20bda257b18f9g946ff23',
+    eventName: 'Fast Break',
+    eventType: 'Public',
+    sportType: 'Rugby',
+    locationResponse: {
+      name: 'Downtown Court',
+      streetNumber: '300',
+      streetName: 'Main St',
+      city: 'Chicago',
+      province: 'IL',
+      country: 'USA',
+      postalCode: '60601',
+      phoneNumber: '312-555-5678',
+      latitude: '41.878113',
+      longitude: '-87.629799',
+    },
+    date: '2025-08-05',
+    maxParticipants: 20,
+    participants: [],
+    createdBy: 'user789',
+    teams: [],
+    cutOffTime: '2025-4-025T19:30:00',
+    description: 'Experience the thrill of a fast-paced basketball match in the heart of Chicago. For advanced players only.',
+    isPrivate: false,
+    whitelistedUsers: [],
+    requiredSkillLevel: ['ADVANCED'],
+  },
+  {
+    id: '67806fs20bda257b18f9946ff23',
+    eventName: 'Fast Break',
+    eventType: 'Public',
+    sportType: 'Ping-Pong',
+    locationResponse: {
+      name: 'Downtown Court',
+      streetNumber: '300',
+      streetName: 'Main St',
+      city: 'Chicago',
+      province: 'IL',
+      country: 'USA',
+      postalCode: '60601',
+      phoneNumber: '312-555-5678',
+      latitude: '41.878113',
+      longitude: '-87.629799',
+    },
+    date: '2025-08-05',
+    maxParticipants: 20,
+    participants: [],
+    createdBy: 'user789',
+    teams: [],
+    cutOffTime: '2025-5-025T19:30:00',
+    description: 'Experience the thrill of a fast-paced basketball match in the heart of Chicago. For advanced players only.',
+    isPrivate: false,
+    whitelistedUsers: [],
+    requiredSkillLevel: ['ADVANCED'],
+  }
+];
+
+
+const EventsList = () => {
+  const scrollY = useRef(new Animated.Value(0)).current;
+  const [refreshing, setRefreshing] = React.useState(false);
+
+  const handleEventPress = (eventId: string) => {
+    // FIXME should reroute to the event page once finished
+    Alert.alert('Event Pressed', `Event ID: ${eventId}`);
+  };
+
+  const onRefresh = () => {
+    setRefreshing(true);
+    // FIXME Here we will simulate a network request once the endpoint is ready
+    setTimeout(() => {
+      setRefreshing(false);
+    }, 2000);
+  };
+  
+  return (
+    <View>
+       <View style={styles.container}>
+      
+        {/* TODO Animated.FlatList is a wrapper around FlatList incase i want to add animation to the scroll */}
+        <FlatList
+            data={events.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())}
+            keyExtractor={(item) => item.id}
+            renderItem={({ item }) => (
+            <EventCard event={item} onPress={handleEventPress} isForProfile={true}/>
+            )}
+            // Adding pull-to-refresh functionality
+            refreshControl={
+            <RefreshControl refreshing={refreshing} onRefresh={onRefresh}/>
+            }
+        />
+        <View>
+            <Text> hi </Text> 
+        </View> 
+    </View>
+    
+    </View>
+    
+    
+  );
+};
+
+export default EventsList;
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: '#f5f5f5',
+    paddingVertical: 10,
+  },
+});

--- a/ClientApp/components/Event/EventListProfilePage.tsx
+++ b/ClientApp/components/Event/EventListProfilePage.tsx
@@ -2,6 +2,7 @@ import React, { useRef } from 'react';
 import { FlatList, View, StyleSheet, Alert, Animated, RefreshControl, Text} from 'react-native';
 import EventCard from './EventCard';
 import { Event } from '@/types/event';
+import { router } from 'expo-router';
 
 // FIXME Sample event data until we can fetch from an API
 const events: Event[] = [
@@ -350,7 +351,8 @@ const EventsList = () => {
 
   const handleEventPress = (eventId: string) => {
     // FIXME should reroute to the event page once finished
-    Alert.alert('Event Pressed', `Event ID: ${eventId}`);
+    eventId = "6782edf7ba257b189946ff27";
+    router.push(`/events/${eventId}`);
   };
 
   const onRefresh = () => {

--- a/ClientApp/components/Event/EventsListHomePage.tsx
+++ b/ClientApp/components/Event/EventsListHomePage.tsx
@@ -2,6 +2,7 @@ import React, { useRef } from 'react';
 import { FlatList, View, StyleSheet, Alert, Animated, RefreshControl } from 'react-native';
 import EventCard from './EventCard';
 import { Event } from '@/types/event';
+import { router } from 'expo-router';
 
 // FIXME Sample event data until we can fetch from an API
 const events: Event[] = [
@@ -350,7 +351,8 @@ const EventsList = () => {
 
   const handleEventPress = (eventId: string) => {
     // FIXME should reroute to the event page once finished
-    Alert.alert('Event Pressed', `Event ID: ${eventId}`);
+    eventId = "6782edf7ba257b189946ff27";
+    router.push(`/events/${eventId}`);
   };
 
   const onRefresh = () => {

--- a/ClientApp/components/Event/EventsListHomePage.tsx
+++ b/ClientApp/components/Event/EventsListHomePage.tsx
@@ -2,7 +2,6 @@ import React, { useRef } from 'react';
 import { FlatList, View, StyleSheet, Alert, Animated, RefreshControl } from 'react-native';
 import EventCard from './EventCard';
 import { Event } from '@/types/event';
-import { router } from 'expo-router';
 
 // FIXME Sample event data until we can fetch from an API
 const events: Event[] = [
@@ -23,12 +22,12 @@ const events: Event[] = [
       latitude: '40.785091',
       longitude: '-73.968285',
     },
-    date: '2025-06-15',
+    date: '2023-06-15',
     maxParticipants: 50,
     participants: [],
     createdBy: 'user123',
     teams: [],
-    cutOffTime: '2025-1-15T22:00:00',
+    cutOffTime: '2024-1-15T22:00:00',
     description: 'Join us for a thrilling sprint event in Central Park. A challenge for both beginners and intermediate runners.',
     isPrivate: false,
     whitelistedUsers: [],
@@ -350,8 +349,8 @@ const EventsList = () => {
   const [refreshing, setRefreshing] = React.useState(false);
 
   const handleEventPress = (eventId: string) => {
-    eventId = "6782edf7ba257b189946ff27";
-    router.push(`/events/${eventId}`);
+    // FIXME should reroute to the event page once finished
+    Alert.alert('Event Pressed', `Event ID: ${eventId}`);
   };
 
   const onRefresh = () => {
@@ -370,7 +369,7 @@ const EventsList = () => {
         data={events}
         keyExtractor={(item) => item.id}
         renderItem={({ item }) => (
-          <EventCard event={item} onPress={handleEventPress} showCapacity={false}/>
+          <EventCard event={item} onPress={handleEventPress} isForProfile={false}/>
         )}
         // Adding pull-to-refresh functionality
         refreshControl={

--- a/ClientApp/components/Home Page/Feed.tsx
+++ b/ClientApp/components/Home Page/Feed.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View, StyleSheet, Text } from 'react-native';
-import EventsList from '../Event/EventsList';
+import EventsList from '../Event/EventsListHomePage';
 
 const Feed = () => {
   return (


### PR DESCRIPTION
for #202 create event card on the profile page with limited information as a summary of the events that the user have participated in 

the card on the profile page has limited information compared to the one one on the homepage. they are ordered from upcoming to past, with the cards for events that expired (happened) in darker color.

![image](https://github.com/user-attachments/assets/85572929-21cf-4cca-8b0e-a3f809d04015)
