### PR TITLE
[fix] Changed the /user/search endpoint from returning a 302 status to a 200

### DIFF
--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/controller/user/UserController.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/controller/user/UserController.java
@@ -111,7 +111,7 @@ public class UserController {
     }
 
     @GetMapping("/search")
-    @ResponseStatus(HttpStatus.FOUND)
+    @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "Search for user",
             description = "Allows the search of users based on name, sport, rank, gender, or date of birth.")
     public Page<ProfileResponse> searchUsers(

--- a/Microservices/user-service/src/test/java/app/sportahub/userservice/service/user/UserServiceTest.java
+++ b/Microservices/user-service/src/test/java/app/sportahub/userservice/service/user/UserServiceTest.java
@@ -31,6 +31,7 @@ import org.mapstruct.factory.Mappers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
 import reactor.core.publisher.Mono;
 
 import java.sql.Timestamp;
@@ -524,7 +525,7 @@ public class UserServiceTest {
 
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
         when(keycloakApiClient.deleteUser("keycloak-123"))
-                .thenReturn(Mono.error(new RuntimeException("Keycloak API error")));
+                .thenReturn(Mono.error(new KeycloakCommunicationException(HttpStatus.CONFLICT,"Keycloak API error")));
 
         assertThrows(KeycloakCommunicationException.class, () -> userService.deleteUserById(userId));
 


### PR DESCRIPTION
The original ResponseStatus of HttpStatus.FOUND was getting caught by the frontend error handling. I changed it to a HttpStatus.OK