### PR TITLE
GH-292: [fix] Fix participant list update

### DIFF
--- a/ClientApp/app/events/[eventId].tsx
+++ b/ClientApp/app/events/[eventId].tsx
@@ -26,8 +26,20 @@ const EventDetails = () => {
         null,
         { params: { userId: user.id } }
       );
+      setEvent((prevEvent) => {
+        if (!prevEvent) return prevEvent;
+        return {
+          ...prevEvent,
+          participants: [
+            ...prevEvent.participants,
+            {
+              userId: user.id,
+              attendStatus: "JOINED",
+            },
+          ],
+        };
+      });
       alert("Successfully joined the event!");
-      router.back();
     } catch (err) {
       console.error(err);
       setError("Failed to join the event.");
@@ -139,7 +151,7 @@ const EventDetails = () => {
                 >
                   <Image
                     source={require("@/assets/images/avatar-placeholder.png")}
-                    style={[styles.participantAvatar, participant.userId === user.id && styles.currentUserBorder ]}
+                    style={[styles.participantAvatar, participant.userId === user.id && styles.currentUserBorder]}
                     testID="participant-avatar"
                   />
                   {participant.userId === user.id && (


### PR DESCRIPTION
Related issue: #292 

### Description
When the user joins an event now, he will be able to see his avatar added automatically in the participants list. This removes the confusion of either the user is enrolled or not. It also gives a better user experience since he does not need to go back and lick again on the event to confirm that he is actually enrolled.

<img width="302" alt="image" src="https://github.com/user-attachments/assets/62a9e024-9479-476f-b004-4938a6943ec2" />
