### PR TITLE
GH-0: [fix] fixed type in endpoint for retrieving events participated in by a user

### DIFF
--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/controller/EventController.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/controller/EventController.java
@@ -91,7 +91,7 @@ public class EventController {
         return eventService.joinEvent(id, userId);
     }
 
-    @GetMapping("/patricipant/{userId}")
+    @GetMapping("/participant/{userId}")
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "Retrieve events by user ID",description = "Retrieve events that a user has participated in")
     public Page<EventResponse> getEventByUserId(@PathVariable String userId, 


### PR DESCRIPTION
This PR is for a quick bug fix. 

There was a typo in the `EventController` endpoint `event/participant/{userId}`. It was previously written `event/patricipant/{userId}`. 