### PR TITLE
GH-317: [fix] Fix Microservice Image Build

### DIFF
--- a/.github/workflows/build-deploy-microservices.yaml
+++ b/.github/workflows/build-deploy-microservices.yaml
@@ -95,7 +95,13 @@ jobs:
       - name: Build with Gradle
         working-directory: Microservices/${{ matrix.service }}
         run: ./gradlew clean build
-
+      - name: Determine JAR File Name
+        id: jar
+        working-directory: Microservices/${{ matrix.service }}
+        run: |
+          JAR_FILE=$(find build/libs -type f -name "*.jar" ! -name "*plain*.jar" | head -n 1)
+          echo "JAR file: $JAR_FILE"
+          echo "jar_file=$JAR_FILE" >> $GITHUB_ENV
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -118,3 +124,4 @@ jobs:
           file: ./Microservices/${{ matrix.service }}/Dockerfile
           push: true
           tags: ghcr.io/${{ env.repo_name }}-${{ env.service_name }}:latest
+          build-args: JAR_FILE=${{ env.jar_file }}


### PR DESCRIPTION
### Fix Microservice Image Build

#### Description
This pull request addresses and resolves the issue with the microservice Docker image failing to run due to an "Invalid or corrupt jarfile" error.

#### Changes Made
- Updated the GitHub Actions workflow to correctly determine the JAR file to be used in the Docker image.
- The script now correctly excludes the "plain" JAR files, ensuring that the Docker image contains the appropriate JAR.
- Added build argument in the Docker build step to pass the correct JAR file path.

#### Impact
This fix ensures that the microservice Docker images are built with valid JAR files and can run successfully without errors.

#### Related Issue
Closes #317

#### Testing
- Verified the workflow runs successfully and the correct JAR file is identified and included in the Docker image.
- Tested running the Docker image locally to ensure no runtime errors occur.