### PR TITLE
GH-320: [feat] Implement Leave Event Endpoint

### DIFF
--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/controller/EventController.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/controller/EventController.java
@@ -95,8 +95,8 @@ public class EventController {
     @PreAuthorize("authentication.name == #userId || hasRole('ROLE_ADMIN')")
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "Leave an event", description = "Enables a user to leave an event, provided they already joined.")
-    public ParticipantResponse leaveEvent(@PathVariable String eventId, @RequestParam String userId) {
-        return eventService.joinEvent(eventId, userId);
+    public ParticipantResponse leaveEvent(@PathVariable String id, @RequestParam String userId) {
+        return eventService.leaveEvent(id, userId);
     }
 
     @GetMapping("/participant/{userId}")

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/controller/EventController.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/controller/EventController.java
@@ -91,6 +91,14 @@ public class EventController {
         return eventService.joinEvent(id, userId);
     }
 
+    @PostMapping("/{id}/leave")
+    @PreAuthorize("authentication.name == #userId || hasRole('ROLE_ADMIN')")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "Leave an event", description = "Enables a user to leave an event, provided they already joined.")
+    public ParticipantResponse leaveEvent(@PathVariable String eventId, @RequestParam String userId) {
+        return eventService.joinEvent(eventId, userId);
+    }
+
     @GetMapping("/participant/{userId}")
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "Retrieve events by user ID",description = "Retrieve events that a user has participated in")

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/exception/event/EventAlreadyStartedException.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/exception/event/EventAlreadyStartedException.java
@@ -1,0 +1,12 @@
+package app.sportahub.eventservice.exception.event;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+@ResponseStatus(code = HttpStatus.FORBIDDEN, reason = "Event already started.")
+public class EventAlreadyStartedException extends ResponseStatusException {
+    public EventAlreadyStartedException(String eventId) {
+        super(HttpStatus.FORBIDDEN, "The event with id: " + eventId + " already started.");
+    }
+}

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/exception/event/EventCreatorCannotLeaveEvent.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/exception/event/EventCreatorCannotLeaveEvent.java
@@ -1,0 +1,12 @@
+package app.sportahub.eventservice.exception.event;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+@ResponseStatus(code = HttpStatus.CONFLICT, reason = "Event creator cannot leave event.")
+public class EventCreatorCannotLeaveEvent extends ResponseStatusException {
+    public EventCreatorCannotLeaveEvent(String eventId, String userId) {
+        super(HttpStatus.CONFLICT, "User with id: " + userId + " is the creator of event id: "
+                + eventId );    }
+}

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/exception/event/EventCreatorCannotLeaveEventException.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/exception/event/EventCreatorCannotLeaveEventException.java
@@ -5,8 +5,8 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.server.ResponseStatusException;
 
 @ResponseStatus(code = HttpStatus.CONFLICT, reason = "Event creator cannot leave event.")
-public class EventCreatorCannotLeaveEvent extends ResponseStatusException {
-    public EventCreatorCannotLeaveEvent(String eventId, String userId) {
+public class EventCreatorCannotLeaveEventException extends ResponseStatusException {
+    public EventCreatorCannotLeaveEventException(String eventId, String userId) {
         super(HttpStatus.CONFLICT, "User with id: " + userId + " is the creator of event id: "
                 + eventId );    }
 }

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/exception/event/UserNotAParticipantException.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/exception/event/UserNotAParticipantException.java
@@ -1,0 +1,13 @@
+package app.sportahub.eventservice.exception.event;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+@ResponseStatus(code = HttpStatus.CONFLICT, reason = "User is not a participant in the event.")
+public class UserNotAParticipantException extends ResponseStatusException {
+    public UserNotAParticipantException(String eventId, String userId) {
+        super(HttpStatus.CONFLICT, "User with id: " + userId + " is not a participant in the event with id: "
+                + eventId + ".");
+    }
+}

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/model/event/participant/ParticipantAttendStatus.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/model/event/participant/ParticipantAttendStatus.java
@@ -3,5 +3,6 @@ package app.sportahub.eventservice.model.event.participant;
 public enum ParticipantAttendStatus {
     JOINED,
     CONFIRMED,
-    CANCELLED
+    CANCELLED,
+    LEFT
 }

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/service/event/EventService.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/service/event/EventService.java
@@ -28,6 +28,8 @@ public interface EventService {
 
     ParticipantResponse joinEvent(String id, String userId);
 
+    ParticipantResponse leaveEvent(String eventId, String userId);
+
     Page<EventResponse> getEventsByParticipantId(String userId, int page, int size, SortDirection sort, EventSortingField field);
 
     Page<EventResponse> getEventsCreatedByUserId(String userId, int page, int size, SortDirection sort, EventSortingField field);

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/service/event/EventServiceImpl.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/service/event/EventServiceImpl.java
@@ -275,13 +275,14 @@ public class EventServiceImpl implements EventService {
             leavingParticipant.setAttendStatus(ParticipantAttendStatus.CANCELLED);
         } else {
             event.getParticipants().remove(leavingParticipant);
+            leavingParticipant.setAttendStatus(ParticipantAttendStatus.LEFT);
         }
 
         eventRepository.save(event);
         log.info("EventServiceImpl::leaveEvent: User with id:{} left event with id:{}", userId, eventId);
         return new ParticipantResponse(
                 leavingParticipant.getUserId(),
-                ParticipantAttendStatus.LEFT,
+                leavingParticipant.getAttendStatus(),
                 leavingParticipant.getJoinedOn()
         );
     }

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/service/event/EventServiceImpl.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/service/event/EventServiceImpl.java
@@ -23,10 +23,8 @@ import org.springframework.stereotype.Service;
 import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 @Slf4j
 @Service("eventService")
@@ -272,7 +270,7 @@ public class EventServiceImpl implements EventService {
         LocalDateTime cutOffDateTime = LocalDateTime.parse(event.getCutOffTime());
 
         if (userId.equals(event.getCreatedBy()))
-            throw new EventCreatorCannotLeaveEvent(eventId, userId);
+            throw new EventCreatorCannotLeaveEventException(eventId, userId);
 
         if (event.getDate().isBefore(currentDate))
             throw new EventAlreadyStartedException(eventId);

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/service/event/EventServiceImpl.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/service/event/EventServiceImpl.java
@@ -267,14 +267,20 @@ public class EventServiceImpl implements EventService {
                 .findFirst()
                 .orElseThrow(() -> new UserNotAParticipantException(eventId, userId));
 
-        if (event.getDate().isBefore(LocalDate.now())) {
-            throw new EventAlreadyStartedException(eventId);
-        }
+        LocalDate currentDate = LocalDate.now();
+        LocalDateTime currentDateTime = LocalDateTime.now();
+        LocalDateTime cutOffDateTime = LocalDateTime.parse(event.getCutOffTime());
 
-        if (LocalDateTime.parse(event.getCutOffTime()).isBefore(LocalDateTime.now())) {
+        if (userId.equals(event.getCreatedBy()))
+            throw new EventCreatorCannotLeaveEvent(eventId, userId);
+
+        if (event.getDate().isBefore(currentDate))
+            throw new EventAlreadyStartedException(eventId);
+
+        if (cutOffDateTime.isBefore(currentDateTime)) {
             leavingParticipant.setAttendStatus(ParticipantAttendStatus.CANCELLED);
         } else {
-            event.getParticipants().remove(leavingParticipant);
+            event.getParticipants().removeIf(p -> p.getUserId().equals(userId));
             leavingParticipant.setAttendStatus(ParticipantAttendStatus.LEFT);
         }
 

--- a/Microservices/event-service/src/test/java/app/sportahub/eventservice/controller/EventControllerTest.java
+++ b/Microservices/event-service/src/test/java/app/sportahub/eventservice/controller/EventControllerTest.java
@@ -187,4 +187,13 @@ public class EventControllerTest {
         assertEquals(eventPage, response);
         Mockito.verify(eventService).getEventsCreatedByUserId("userId", 0, 10, SortDirection.DESC, EventSortingField.DATE);
     }
+
+    @Test void testLeaveEvent() {
+        Mockito.when(eventService.leaveEvent(anyString(), anyString())).thenReturn(participantResponse);
+
+        ParticipantResponse response = eventController.leaveEvent("testId", "userId");
+
+        assertEquals(participantResponse, response);
+        Mockito.verify(eventService).leaveEvent("testId", "userId");
+    }
 }

--- a/Microservices/event-service/src/test/java/app/sportahub/eventservice/service/event/EventServiceTest.java
+++ b/Microservices/event-service/src/test/java/app/sportahub/eventservice/service/event/EventServiceTest.java
@@ -474,7 +474,7 @@ class EventServiceTest {
         when(eventRepository.findById(eventId)).thenReturn(Optional.of(event));
 
         // Act & Assert
-        assertThrows(EventCreatorCannotLeaveEvent.class, () -> eventServiceImpl.leaveEvent(eventId, userId));
+        assertThrows(EventCreatorCannotLeaveEventException.class, () -> eventServiceImpl.leaveEvent(eventId, userId));
     }
 
     @Test

--- a/Microservices/event-service/src/test/java/app/sportahub/eventservice/service/event/EventServiceTest.java
+++ b/Microservices/event-service/src/test/java/app/sportahub/eventservice/service/event/EventServiceTest.java
@@ -461,6 +461,23 @@ class EventServiceTest {
     }
 
     @Test
+    void leaveEvent_CreatorCannotLeave_ThrowsException() {
+        // Arrange
+        String eventId = "event123";
+        String userId = "user456";
+        Event event = new Event();
+        event.setId(eventId);
+        event.setCreatedBy(userId);
+        event.setCutOffTime(LocalDateTime.now().toString());
+        event.setParticipants(new ArrayList<>(List.of(new Participant(userId, ParticipantAttendStatus.JOINED, LocalDate.now()))));
+
+        when(eventRepository.findById(eventId)).thenReturn(Optional.of(event));
+
+        // Act & Assert
+        assertThrows(EventCreatorCannotLeaveEvent.class, () -> eventServiceImpl.leaveEvent(eventId, userId));
+    }
+
+    @Test
     void leaveEvent_AfterCutOffTime_SetsCancelledStatus() {
         // Arrange
         String eventId = "event123";


### PR DESCRIPTION
# Description
This pull request focuses on the creation of `event/{id}/leave` endpoint to allow users to leave an event, provided they are not the creator and has not started.

## File Changes & Additions
- EventController.java: Add new endpoint
- EventAlreadyStartedException.java: Add EventAlreadyStartedException exception 
- EventCreatorCannotLeaveException.java: Add EventCreatorCannotLeaveException exception 
- UserNotAParticipantException.java: Add UserNotAParticipantException exception 
- EventService.java: Add leaveEvent method
- EventServiceImpl.java: Implement leaveEvent method
- EventControllerTest.java Add new test cases for leave endpoint
- EventServiceTest.java Add new test cases for leave service logic

## Tests
- Successfully send request ✔️
- Throw exception if creators tries to leave their event✔️
- Throw exception if user tries to leave an event they do not participate in ✔️ 
- Throw exception if participant tries to leave an event that has already started ✔️ 