### PR TITLE
GH-0: [chore] Changing jdk version to Java 21 for storage service

### DIFF
--- a/Microservices/storage-service/build.gradle
+++ b/Microservices/storage-service/build.gradle
@@ -9,7 +9,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
+		languageVersion = JavaLanguageVersion.of(21)
 	}
 }
 


### PR DESCRIPTION
Hot fix to change jdk version from Java 17 to Java 21 for storage service