### PR TITLE
GH-335: [feat] Add Event state enums & Event Cancellation model

### DIFF
--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/controller/EventController.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/controller/EventController.java
@@ -1,5 +1,6 @@
 package app.sportahub.eventservice.controller;
 
+import app.sportahub.eventservice.dto.request.EventCancellationRequest;
 import app.sportahub.eventservice.dto.request.EventRequest;
 import app.sportahub.eventservice.dto.response.EventResponse;
 import app.sportahub.eventservice.dto.response.ParticipantResponse;
@@ -121,5 +122,14 @@ public class EventController {
                                                         @RequestParam(defaultValue = "DATE") EventSortingField field
                                             ) {
         return eventService.getEventsCreatedByUserId(userId, page, size, sort, field);
+    }
+
+    @PatchMapping("/{id}/cancel")
+    @PreAuthorize("@eventService.isCreator(#id, authentication.name) || hasRole('ROLE_ADMIN')")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "Cancel an event", description = "Marks an event as 'Cancelled' instead of deleting it.")
+    public EventResponse cancelEvent(@PathVariable String id,
+                                     @RequestBody @Valid EventCancellationRequest cancelRequest) {
+        return eventService.cancelEvent(id, cancelRequest);
     }
 }

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/dto/request/EventCancellationRequest.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/dto/request/EventCancellationRequest.java
@@ -1,0 +1,7 @@
+package app.sportahub.eventservice.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+public record EventCancellationRequest(
+        @NotBlank(message = "Cancellation reason must be provided")
+        String reason) {
+}

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/dto/response/EventResponse.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/dto/response/EventResponse.java
@@ -1,6 +1,7 @@
 package app.sportahub.eventservice.dto.response;
 
 import app.sportahub.eventservice.enums.SkillLevelEnum;
+import app.sportahub.eventservice.model.event.EventCancellation;
 import app.sportahub.eventservice.model.event.Team;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
@@ -16,5 +17,5 @@ public record EventResponse(String id, Timestamp creationDate, String eventName,
                             String duration, Integer maxParticipants, List<ParticipantResponse> participants,
                             String createdBy, List<Team> teams, String cutOffTime, String description,
                             Boolean isPrivate, List<String> whitelistedUsers,
-                            EnumSet<SkillLevelEnum> requiredSkillLevel) {
+                            EnumSet<SkillLevelEnum> requiredSkillLevel, EventCancellation cancellation) {
 }

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/enums/EventState.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/enums/EventState.java
@@ -1,0 +1,5 @@
+package app.sportahub.eventservice.enums;
+
+public enum EventState {
+    ACTIVE, CANCELLED
+}

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/exception/event/EventAlreadyCancelledException.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/exception/event/EventAlreadyCancelledException.java
@@ -1,0 +1,13 @@
+package app.sportahub.eventservice.exception.event;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+
+@ResponseStatus(code = HttpStatus.CONFLICT, reason = "Event is already cancelled.")
+public class EventAlreadyCancelledException extends ResponseStatusException {
+    public EventAlreadyCancelledException(String eventId) {
+        super(HttpStatus.CONFLICT, "The event with id " + eventId + " is already cancelled.");
+    }
+}

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/model/event/Event.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/model/event/Event.java
@@ -1,8 +1,10 @@
 package app.sportahub.eventservice.model.event;
 
+import app.sportahub.eventservice.enums.EventState;
 import app.sportahub.eventservice.enums.SkillLevelEnum;
 import app.sportahub.eventservice.model.BaseEntity;
 import app.sportahub.eventservice.model.event.participant.Participant;
+import com.mongodb.lang.Nullable;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -74,4 +76,10 @@ public class Event extends BaseEntity {
 
     @Builder.Default
     private EnumSet<SkillLevelEnum> requiredSkillLevel = EnumSet.allOf(SkillLevelEnum.class);
+
+    @Builder.Default
+    private EventState state = EventState.ACTIVE;
+
+    @Nullable
+    private EventCancellation cancellation;
 }

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/model/event/EventCancellation.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/model/event/EventCancellation.java
@@ -1,0 +1,17 @@
+package app.sportahub.eventservice.model.event;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.sql.Timestamp;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Builder
+public class EventCancellation {
+    private String cancelledBy;
+    private String reason;
+    private Timestamp cancelledAt;
+}

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/service/event/EventService.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/service/event/EventService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 
 import app.sportahub.eventservice.dto.request.EventRequest;
+import app.sportahub.eventservice.dto.request.EventCancellationRequest;
 import app.sportahub.eventservice.dto.response.EventResponse;
 import app.sportahub.eventservice.dto.response.ParticipantResponse;
 import app.sportahub.eventservice.enums.EventSortingField;
@@ -33,4 +34,6 @@ public interface EventService {
     Page<EventResponse> getEventsByParticipantId(String userId, int page, int size, SortDirection sort, EventSortingField field);
 
     Page<EventResponse> getEventsCreatedByUserId(String userId, int page, int size, SortDirection sort, EventSortingField field);
+
+    EventResponse cancelEvent(String id, EventCancellationRequest cancelRequest);
 }

--- a/Microservices/event-service/src/test/java/app/sportahub/eventservice/controller/EventControllerTest.java
+++ b/Microservices/event-service/src/test/java/app/sportahub/eventservice/controller/EventControllerTest.java
@@ -1,5 +1,6 @@
 package app.sportahub.eventservice.controller;
 
+import app.sportahub.eventservice.dto.request.EventCancellationRequest;
 import app.sportahub.eventservice.dto.request.EventRequest;
 import app.sportahub.eventservice.dto.response.EventResponse;
 import app.sportahub.eventservice.dto.response.ParticipantResponse;
@@ -41,10 +42,12 @@ public class EventControllerTest {
 
     private EventResponse eventResponse;
     private EventRequest eventRequest;
+    private EventCancellationRequest cancelRequest;
     private ParticipantResponse participantResponse;
 
     @BeforeEach
     public void setUp() {
+        cancelRequest = new EventCancellationRequest("Weather conditions");
         eventResponse = new EventResponse(
                 "1",
                 Timestamp.valueOf("2023-01-01 10:00:00"),
@@ -64,7 +67,8 @@ public class EventControllerTest {
                 "Join us for a friendly match!",
                 false,
                 List.of("User111", "User222"),
-                EnumSet.of(SkillLevelEnum.BEGINNER, SkillLevelEnum.INTERMEDIATE)
+                EnumSet.of(SkillLevelEnum.BEGINNER, SkillLevelEnum.INTERMEDIATE),
+                null
         );
 
 
@@ -195,5 +199,15 @@ public class EventControllerTest {
 
         assertEquals(participantResponse, response);
         Mockito.verify(eventService).leaveEvent("testId", "userId");
+    }
+
+    @Test
+    public void testCancelEvent() {
+        Mockito.when(eventService.cancelEvent(anyString(), any(EventCancellationRequest.class))).thenReturn(eventResponse);
+
+        EventResponse response = eventController.cancelEvent("testId", cancelRequest);
+
+        assertEquals(eventResponse, response);
+        Mockito.verify(eventService).cancelEvent("testId", cancelRequest);
     }
 }

--- a/Microservices/event-service/src/test/java/app/sportahub/eventservice/mapper/event/EventMapperTest.java
+++ b/Microservices/event-service/src/test/java/app/sportahub/eventservice/mapper/event/EventMapperTest.java
@@ -57,6 +57,8 @@ public class EventMapperTest {
                 null,
                 null,
                 null,
+                null,
+                null,
                 null);
 
         //Act


### PR DESCRIPTION
## 📌 Summary
This PR introduces the **event cancellation feature**, allowing events to be marked as `CANCELLED` instead of being deleted. The following changes have been implemented:

1. **Added `EventState` Enum**:
   - Defines the possible states for an event: `ACTIVE` and `CANCELLED`.

2. **Introduced `EventCancellation` Model**:
   - Stores cancellation metadata (`cancelledBy`, `reason`, `cancelledAt`).
   - Embedded within the `Event` model to track cancellations directly.

3. **Implemented `cancelEvent` API Endpoint**:
   - Added a new `PATCH /event/{id}/cancel` endpoint.
   - Only the **event creator** or **admin** can cancel events.
   - Requires a reason for cancellation.

4. **Modified `EventResponse` to Include `EventCancellation`**:
   - Updated DTO to return cancellation details.

5. **Added Exception Handling**:
   - `EventDoesNotExistException` if the event does not exist.
   - `EventAlreadyCancelledException` if the event is already cancelled.

6. **Wrote Unit Tests for Event Cancellation**:
   - Tested valid and invalid cancellation scenarios.

---

## ✨ **Key Changes**
### ✅ **Event Model Updates**
- Added `EventState state = EventState.ACTIVE;`
- Embedded `EventCancellation cancellation;` into the `Event` model.

### ✅ **New DTOs**
- `EventCancellationRequest`: Accepts a reason for cancellation.

### ✅ **Controller Changes**
- Added `/event/{id}/cancel` in `EventController`.

### ✅ **Service Implementation**
- Implemented `cancelEvent` in `EventServiceImpl`.

### ✅ **New Exception**
- `EventAlreadyCancelledException`: Prevents redundant cancellations.

### ✅ **Unit Tests**
- Ensures proper authorization and validation before cancellation.