### PR TITLE
GH-0: [feat] Fix Failing Test and Update leaveEvent Logic

### DIFF
--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/service/event/EventServiceImpl.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/service/event/EventServiceImpl.java
@@ -274,7 +274,8 @@ public class EventServiceImpl implements EventService {
         if (userId.equals(event.getCreatedBy()))
             throw new EventCreatorCannotLeaveEventException(eventId, userId);
 
-        if (event.getStartTime().isBefore(currentTime))
+        if (event.getDate().isBefore(currentDate) ||
+                (event.getDate().isEqual(currentDate) && event.getStartTime().isBefore(currentTime)))
             throw new EventAlreadyStartedException(eventId);
 
         if (cutOffDateTime.isBefore(currentDateTime)) {

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/service/event/EventServiceImpl.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/service/event/EventServiceImpl.java
@@ -23,6 +23,7 @@ import org.springframework.stereotype.Service;
 import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -266,13 +267,14 @@ public class EventServiceImpl implements EventService {
                 .orElseThrow(() -> new UserNotAParticipantException(eventId, userId));
 
         LocalDate currentDate = LocalDate.now();
+        LocalTime currentTime = LocalTime.now();
         LocalDateTime currentDateTime = LocalDateTime.now();
         LocalDateTime cutOffDateTime = LocalDateTime.parse(event.getCutOffTime());
 
         if (userId.equals(event.getCreatedBy()))
             throw new EventCreatorCannotLeaveEventException(eventId, userId);
 
-        if (event.getDate().isBefore(currentDate))
+        if (event.getStartTime().isBefore(currentTime))
             throw new EventAlreadyStartedException(eventId);
 
         if (cutOffDateTime.isBefore(currentDateTime)) {

--- a/Microservices/event-service/src/test/java/app/sportahub/eventservice/service/event/EventServiceTest.java
+++ b/Microservices/event-service/src/test/java/app/sportahub/eventservice/service/event/EventServiceTest.java
@@ -24,6 +24,7 @@ import org.springframework.data.domain.Pageable;
 import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -401,6 +402,7 @@ class EventServiceTest {
         event.setId(eventId);
         event.setDate(eventDate);
         event.setCutOffTime(cutOffTime.toString());
+        event.setStartTime(LocalTime.now().plusHours(1));
         event.setParticipants(new ArrayList<>(List.of(participant)));
 
         when(eventRepository.findById(eventId)).thenReturn(Optional.of(event));
@@ -451,7 +453,8 @@ class EventServiceTest {
         String userId = "user456";
         Event event = new Event();
         event.setId(eventId);
-        event.setDate(LocalDate.now().minusDays(1)); // Event already started
+        event.setStartTime(LocalTime.now().minusHours(1)); // Event already started
+        event.setCutOffTime(LocalDateTime.now().minusDays(2).toString());
         event.setParticipants(new ArrayList<>(List.of(new Participant(userId, ParticipantAttendStatus.JOINED, LocalDate.now()))));
 
         when(eventRepository.findById(eventId)).thenReturn(Optional.of(event));
@@ -488,6 +491,7 @@ class EventServiceTest {
         Event event = new Event();
         event.setId(eventId);
         event.setDate(LocalDate.now().plusDays(1));
+        event.setStartTime(LocalTime.now().plusHours(1));
         event.setCutOffTime(pastCutOffTime.toString());
         event.setParticipants(new ArrayList<>(List.of(participant)));
 

--- a/Microservices/event-service/src/test/java/app/sportahub/eventservice/service/event/EventServiceTest.java
+++ b/Microservices/event-service/src/test/java/app/sportahub/eventservice/service/event/EventServiceTest.java
@@ -453,6 +453,7 @@ class EventServiceTest {
         String userId = "user456";
         Event event = new Event();
         event.setId(eventId);
+        event.setDate(LocalDate.now().minusDays(1));
         event.setStartTime(LocalTime.now().minusHours(1)); // Event already started
         event.setCutOffTime(LocalDateTime.now().minusDays(2).toString());
         event.setParticipants(new ArrayList<>(List.of(new Participant(userId, ParticipantAttendStatus.JOINED, LocalDate.now()))));


### PR DESCRIPTION
# Description

This PR aims to fix test failure and also update mistake in recently merged branch, namely the following:

The correct logic of leaveEvent feature is to throw EventAlreadyStartedException when the a participant is trying to leave after the event's start _time_, not event's start _date_. 