### PR TITLE
Get Events That Matches The User's Profile For Their Home Page Browsing

### DIFF
--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/config/MongoConfig.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/config/MongoConfig.java
@@ -55,6 +55,11 @@ public class MongoConfig extends AbstractMongoClientConfiguration {
         return "event-service";
     }
 
+    @Override
+    public boolean autoIndexCreation() {
+      return true;
+    }
+
     @Bean
     @Override
     public MongoCustomConversions customConversions() {

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/controller/event/EventController.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/controller/event/EventController.java
@@ -15,6 +15,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
@@ -43,6 +44,21 @@ public class EventController {
             description = "Fetches all events in the database.")
     public List<EventResponse> getAllEvents() {
         return eventService.getAllEvents();
+    }
+
+    @GetMapping("/relevant-events")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "Retrieve events by location", 
+            description = "Fetches events based on the provided location.")
+    public ResponseEntity<?> getEventsByLocation(
+            @RequestParam double longitude,
+            @RequestParam double latitude,
+            @RequestParam(defaultValue = "25.0") double radius,
+            @RequestParam(defaultValue= "false") boolean radiusExpansion,
+            @RequestParam(defaultValue = "true") boolean paginate,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        return eventService.getRelevantEvents(longitude, latitude, radius, radiusExpansion, paginate, page, size);
     }
 
     @PostMapping
@@ -105,11 +121,10 @@ public class EventController {
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "Retrieve events by user ID", description = "Retrieve events that a user has participated in")
     public Page<EventResponse> getEventByUserId(@PathVariable String userId,
-                                                @RequestParam(defaultValue = "0") int page,
-                                                @RequestParam(defaultValue = "10") int size,
-                                                @RequestParam(defaultValue = "DESC") SortDirection sort,
-                                                @RequestParam(defaultValue = "DATE") EventSortingField field
-    ) {
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "DESC") SortDirection sort,
+            @RequestParam(defaultValue = "DATE") EventSortingField field) {
         return eventService.getEventsByParticipantId(userId, page, size, sort, field);
     }
 
@@ -117,11 +132,10 @@ public class EventController {
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "Retrieve events created by user ID", description = "Retrieve events that a user has created")
     public Page<EventResponse> getEventsCreatedByUserId(@PathVariable String userId,
-                                                        @RequestParam(defaultValue = "0") int page,
-                                                        @RequestParam(defaultValue = "10") int size,
-                                                        @RequestParam(defaultValue = "DESC") SortDirection sort,
-                                                        @RequestParam(defaultValue = "DATE") EventSortingField field
-    ) {
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "DESC") SortDirection sort,
+            @RequestParam(defaultValue = "DATE") EventSortingField field) {
         return eventService.getEventsCreatedByUserId(userId, page, size, sort, field);
     }
 
@@ -130,7 +144,7 @@ public class EventController {
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "Cancel an event", description = "Marks an event as 'Cancelled' instead of deleting it.")
     public EventResponse cancelEvent(@PathVariable String id,
-                                     @RequestBody @Valid EventCancellationRequest cancelRequest) {
+            @RequestBody @Valid EventCancellationRequest cancelRequest) {
         return eventService.cancelEvent(id, cancelRequest);
     }
 
@@ -138,7 +152,7 @@ public class EventController {
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "React to an event", description = "Enables a user to react to an event.")
     public ReactionResponse reactToEvent(@PathVariable String id,
-                                         @RequestParam ReactionType reaction) {
+            @RequestParam ReactionType reaction) {
         return eventService.reactToEvent(id, reaction);
     }
 }

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/dto/request/event/LocationRequest.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/dto/request/event/LocationRequest.java
@@ -1,5 +1,7 @@
 package app.sportahub.eventservice.dto.request.event;
 
+import org.springframework.data.mongodb.core.geo.GeoJsonPoint;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.mongodb.lang.Nullable;
 import jakarta.validation.constraints.NotBlank;
@@ -31,10 +33,7 @@ public record LocationRequest(@NotBlank(message = "Location name must be provide
 
                               @Nullable
                               String phoneNumber,
-
-                              @Nullable
-                              String latitude,
-
-                              @Nullable
-                              String longitude) {
+                              
+                              @NotBlank(message = "Coordinates must be provided")
+                              GeoJsonPoint coordinates ) {
 }

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/dto/response/LocationResponse.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/dto/response/LocationResponse.java
@@ -1,9 +1,11 @@
 package app.sportahub.eventservice.dto.response;
 
+import org.springframework.data.mongodb.core.geo.GeoJsonPoint;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record LocationResponse(String name, String streetNumber, String streetName, String city, String province,
                                String country, String postalCode, String addressLine2, String phoneNumber,
-                               String latitude, String longitude) {
+                               GeoJsonPoint coordinates) {
 }

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/exception/event/EventsNotFoundException.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/exception/event/EventsNotFoundException.java
@@ -1,0 +1,13 @@
+package app.sportahub.eventservice.exception.event;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+@ResponseStatus(code = HttpStatus.NOT_FOUND, reason = "Events not found.")
+public class EventsNotFoundException extends ResponseStatusException {
+
+    public EventsNotFoundException() {
+        super(HttpStatus.NOT_FOUND, "No events matching the provided criteria were found.");
+    }
+}

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/model/event/Location.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/model/event/Location.java
@@ -1,5 +1,11 @@
 package app.sportahub.eventservice.model.event;
 
+
+
+import org.springframework.data.mongodb.core.geo.GeoJsonPoint;
+import org.springframework.data.mongodb.core.index.GeoSpatialIndexType;
+import org.springframework.data.mongodb.core.index.GeoSpatialIndexed;
+
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -27,10 +33,12 @@ public class Location {
     @NotBlank(message = "Country must be provided")
     private String country;
 
-
     private String postalCode;
     private String addressLine2;
     private String phoneNumber;
-    private String latitude;
-    private String longitude;
+
+    @GeoSpatialIndexed(type = GeoSpatialIndexType.GEO_2DSPHERE)
+    @NotBlank(message = "Location type must be provided")
+    private GeoJsonPoint coordinates;
+
 }

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/repository/event/EventRepository.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/repository/event/EventRepository.java
@@ -3,6 +3,8 @@ package app.sportahub.eventservice.repository.event;
 import app.sportahub.eventservice.model.event.Event;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.geo.Distance;
+import org.springframework.data.mongodb.core.geo.GeoJsonPoint;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
@@ -12,6 +14,8 @@ import java.util.Optional;
 public interface EventRepository extends MongoRepository<Event, String> {
 
     Optional<Event> findEventById(String id);
+
+    Page<Event> findByLocationCoordinatesNear(GeoJsonPoint point, Distance distance, Pageable pageable);
 
     Optional<Event> findEventByEventName(String eventName);
 

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/service/event/EventService.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/service/event/EventService.java
@@ -2,22 +2,25 @@ package app.sportahub.eventservice.service.event;
 
 import java.util.List;
 
-import app.sportahub.eventservice.dto.response.ReactionResponse;
-import app.sportahub.eventservice.model.event.reactor.ReactionType;
 import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
 
-import app.sportahub.eventservice.dto.request.event.EventRequest;
 import app.sportahub.eventservice.dto.request.event.EventCancellationRequest;
+import app.sportahub.eventservice.dto.request.event.EventRequest;
 import app.sportahub.eventservice.dto.response.EventResponse;
 import app.sportahub.eventservice.dto.response.ParticipantResponse;
+import app.sportahub.eventservice.dto.response.ReactionResponse;
 import app.sportahub.eventservice.enums.EventSortingField;
 import app.sportahub.eventservice.enums.SortDirection;
+import app.sportahub.eventservice.model.event.reactor.ReactionType;
 
 public interface EventService {
 
     EventResponse getEventById(String id);
 
     List<EventResponse> getAllEvents();
+
+    ResponseEntity<?> getRelevantEvents(double longitude, double latitude, double radius, boolean radiusExpansion, boolean paginate, int page, int size);
 
     EventResponse createEvent(EventRequest eventRequest);
 

--- a/Microservices/event-service/src/main/resources/application.properties
+++ b/Microservices/event-service/src/main/resources/application.properties
@@ -43,4 +43,4 @@ springdoc.swagger-ui.urls[1].name=Local
 springdoc.swagger-ui.urls[1].url=http://localhost:8080/api/event-service/api-docs
 
 # Spring Data MongoDB
-spring.data.mongodb.uri=${MONGODB_URI:mongodb://root:password@sporta-host:27017/event-service?authSource=admin}
+spring.data.mongodb.uri=${MONGODB_URI:mongodb://root:password@sporta-dev:27017/event-service?authSource=admin}

--- a/Microservices/event-service/src/test/java/app/sportahub/eventservice/controller/event/EventControllerTest.java
+++ b/Microservices/event-service/src/test/java/app/sportahub/eventservice/controller/event/EventControllerTest.java
@@ -20,6 +20,8 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 
 import java.sql.Timestamp;
 import java.time.LocalDate;
@@ -125,6 +127,62 @@ public class EventControllerTest {
 
         assertEquals(eventList, response);
         Mockito.verify(eventService).getAllEvents();
+    }
+
+    @Test
+    public void testGetEventsByLocationReturnList() {
+        List<EventResponse> eventList = Arrays.asList(eventResponse);
+        Mockito.when(eventService.getRelevantEvents(
+                any(double.class),
+                any(double.class),
+                any(double.class),
+                any(boolean.class),
+                any(boolean.class),
+                any(int.class),
+                any(int.class)
+        )).thenReturn((ResponseEntity) ResponseEntity.ok(eventList));
+
+        ResponseEntity<?> response = eventController.getEventsByLocation(-74.0060,40.7128, 25.0, false, false, 0, 10);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(eventList, response.getBody());
+        Mockito.verify(eventService).getRelevantEvents(
+                Mockito.eq(-74.0060),
+                Mockito.eq(40.7128),
+                Mockito.eq(25.0),
+                Mockito.eq(false),
+                Mockito.eq(false),
+                Mockito.eq(0),
+                Mockito.eq(10)
+        );
+    }
+
+    @Test
+    public void testGetEventsByLocationReturnPage() {
+        Page<EventResponse> eventList = new PageImpl<>(Collections.singletonList(eventResponse));
+        Mockito.when(eventService.getRelevantEvents(
+                any(double.class),
+                any(double.class),
+                any(double.class),
+                any(boolean.class),
+                any(boolean.class),
+                any(int.class),
+                any(int.class)
+        )).thenReturn((ResponseEntity) ResponseEntity.ok(eventList));
+
+        ResponseEntity<?> response = eventController.getEventsByLocation(-74.0060,40.7128, 25.0, false, true, 0, 10);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(eventList, response.getBody());
+        Mockito.verify(eventService).getRelevantEvents(
+                Mockito.eq(-74.0060),
+                Mockito.eq(40.7128),
+                Mockito.eq(25.0),
+                Mockito.eq(false),
+                Mockito.eq(true),
+                Mockito.eq(0),
+                Mockito.eq(10)
+        );
     }
 
     @Test

--- a/Microservices/event-service/src/test/java/app/sportahub/eventservice/mapper/event/EventMapperTest.java
+++ b/Microservices/event-service/src/test/java/app/sportahub/eventservice/mapper/event/EventMapperTest.java
@@ -11,6 +11,7 @@ import app.sportahub.eventservice.model.event.participant.Participant;
 import app.sportahub.eventservice.model.event.participant.ParticipantAttendStatus;
 import org.junit.jupiter.api.Test;
 import org.mapstruct.factory.Mappers;
+import org.springframework.data.mongodb.core.geo.GeoJsonPoint;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -78,6 +79,7 @@ public class EventMapperTest {
 
     @Test
     public void testPatchEventFromRequest() {
+        GeoJsonPoint coordinates = new GeoJsonPoint(1, 1);
         //Arrange
         Location location = Location.builder()
                 .withName("locationName")
@@ -89,8 +91,7 @@ public class EventMapperTest {
                 .withPostalCode("postalCode")
                 .withAddressLine2("addressLine2")
                 .withPhoneNumber("phoneNumber")
-                .withLatitude("latitude")
-                .withLongitude("longitude")
+                .withCoordinates(coordinates)
                 .build();
 
         Participant participant = Participant.builder()
@@ -165,6 +166,7 @@ public class EventMapperTest {
     @Test
     public void testLocationRequestToLocation1() {
         // Arrange
+        GeoJsonPoint coordinates = new GeoJsonPoint(1, 1);
         Event event = new Event();
         event.setLocation(new Location(
                 "name",
@@ -176,11 +178,10 @@ public class EventMapperTest {
                 "postalCode",
                 "addressLine2",
                 "phoneNumber",
-                "latitude",
-                "longitude"));
+                coordinates
+                ));
 
         LocationRequest locationRequest = new LocationRequest(
-                null,
                 null,
                 null,
                 null,
@@ -227,7 +228,6 @@ public class EventMapperTest {
         assertNotNull(event.getLocation().getPostalCode());
         assertNotNull(event.getLocation().getAddressLine2());
         assertNotNull(event.getLocation().getPhoneNumber());
-        assertNotNull(event.getLocation().getLatitude());
-        assertNotNull(event.getLocation().getLongitude());
+        assertNotNull(event.getLocation().getCoordinates());
     }
 }


### PR DESCRIPTION
# Overview 

This PR is for issue #334 which introduces browsing events that are in your proximity. 

## Key changes 
- `EventController`: Added endpoint `event/relevant-events` to retrieve the relevant events and has the following request parameters : 
>- `longitude` : a double for the longitude of the users location 
>- `latitude`: a double for the latitude of the users location 
>- `radius`: a double for the search radius of events 
>- `radiusExpansion`: a **Boolean** indicating whether or not to expand the search radius if no events found in given radius
>- `paginate`: a **Boolean** indicating whether or not the returned results are paginated 
>- `page`: an **Integer** indicating the page for paginated response 
>- `size`: an **Integer** indicating the size of each page for paginated response 
- `UserServiceImpl` (and `UserService` ) : added a method for finding relevant events based on your location 
- `Location`: Replaced the `longitude` and `latitude` attributes by a `GeoJsonPoint` attribute named `coordinates`. 
- `EventRepository`: Added a `findByLocationCoordinatesNear` to locate event objects within a given radius of the current users location. 

## How to test 
Run tests using the following command in terminal:
```
./gradlew test
```