### PR TITLE
[hotfix] 404 getFriends issue

### DIFF
--- a/Microservices/user-service/src/main/java/app/sportahub/userservice/service/user/UserServiceImpl.java
+++ b/Microservices/user-service/src/main/java/app/sportahub/userservice/service/user/UserServiceImpl.java
@@ -493,7 +493,7 @@ public class UserServiceImpl implements UserService {
 
         List<UserProfileResponse> userProfileResponses = users.stream()
                 .map(user -> new UserProfileResponse(user.getId(), profileMapper.profileToProfileResponse(user.getProfile())))
-                .collect(toList());
+                .collect(Collectors.toList());
         return new PageImpl<>(userProfileResponses, users.getPageable(), users.getTotalElements());
     }
 }

--- a/Microservices/user-service/src/test/java/app/sportahub/userservice/service/user/UserServiceTest.java
+++ b/Microservices/user-service/src/test/java/app/sportahub/userservice/service/user/UserServiceTest.java
@@ -1131,41 +1131,6 @@ public class UserServiceTest {
     }
 
     @Test
-    void deleteFriendShouldThrowFriendUserDoesNotExistException() {
-        // Arrange
-        User requester = new User();
-        requester.setId("userId1");
-
-        User friend = new User();
-        String friendFriendUserId = new ObjectId().toHexString();
-        friend.setId(friendFriendUserId);
-
-        Friend requesterFriend = new Friend(friendFriendUserId, FriendRequestStatusEnum.ACCEPTED);
-        requesterFriend.setId("friend1Id");
-
-        Friend friendFriend = new Friend(requester.getId(), FriendRequestStatusEnum.ACCEPTED);
-        friendFriend.setId("friend2Id");
-
-        List<Friend> requesterFriendList = new ArrayList<>();
-        requesterFriendList.add(requesterFriend);
-        requester.setFriendList(requesterFriendList);
-
-        List<Friend> friendFriendList = new ArrayList<>();
-        friendFriendList.add(friendFriend);
-        friend.setFriendList(friendFriendList);
-
-        when(userRepository.findUserById(requester.getId())).thenReturn(Optional.of(requester));
-
-        // Act
-        UserDoesNotExistException exception = assertThrows(UserDoesNotExistException.class, () ->
-                userService.deleteFriend(requester.getId(), requesterFriend.getId()));
-
-        // Assert
-        assertEquals("404 NOT_FOUND \"User with identifier: " + friendFriendUserId + " does not exist.\"",
-                exception.getMessage());
-    }
-
-    @Test
     void deleteFriendShouldReturnRequesterFriendNotFoundInFriendListException() {
         // Arrange
         String wrongId = new ObjectId().toHexString();
@@ -1202,35 +1167,4 @@ public class UserServiceTest {
                 exception.getMessage());
     }
 
-    @Test
-    void deleteFriendShouldReturnFriendFriendNotFoundInFriendListException() {
-        // Arrange
-        User requester = new User();
-        requester.setId("userId1");
-
-        User friend = new User();
-        friend.setId("userId2");
-
-        Friend requesterFriend = new Friend(friend.getId(), FriendRequestStatusEnum.ACCEPTED);
-        requesterFriend.setId("friend1Id");
-
-        Friend friendFriend = new Friend(friend.getId(), FriendRequestStatusEnum.ACCEPTED);
-        friendFriend.setId("friend2Id");
-
-        List<Friend> requesterFriendList = new ArrayList<>();
-        requesterFriendList.add(requesterFriend);
-        requester.setFriendList(requesterFriendList);
-
-        lenient().when(userRepository.findUserById(requester.getId())).thenReturn(Optional.of(requester));
-        lenient().when(userRepository.findUserById(friend.getId())).thenReturn(Optional.of(friend));
-
-        // Act
-        FriendNotFoundInFriendListException exception = assertThrows(FriendNotFoundInFriendListException.class, () ->
-                userService.deleteFriend(requester.getId(), requesterFriend.getId()));
-
-        // Assert
-        assertEquals("404 NOT_FOUND \"User with identifier: " + friend.getId()
-                        + " does not have friend with identifier: " + requester.getId() + " in their friend list.\"",
-                exception.getMessage());
-    }
 }


### PR DESCRIPTION
The getFriends endpoint was returning 404 when trying to return users no longer in the database. Now it will remove them from the friendList and delete them before returning if they can't be found in the database.

This led me to realize that friends could only be deleted if they appeared in both friendLists (Requester and Friend), which shouldn't have been the case.  That's also fixed.

Also, friend requests could be sent to users already accepted into the friendList, now there's a check preventing that in the sendFriendRequest method.

### To test:
1. You need two valid user accouts (one of which you'll delete)
2. Run the user-service locally
3. Using Swagger/Postman, log into one of the users and add the other as a friend
4. Delete the user you just added as a friend
5. Call the get friends endpoint, which should return a list that does not include the deleted friend.