### PR TITLE
Feature/issue 373/events map view

### DIFF
--- a/ClientApp/app/(tabs)/create/index.tsx
+++ b/ClientApp/app/(tabs)/create/index.tsx
@@ -58,8 +58,10 @@ const Create = () => {
     city: string;
     province: string;
     country: string;
-    latitude: string;
-    longitude: string;
+    coordinates: {
+      coordinates: number[];
+      type: string;
+    };
   }
 
   const [location, setLocation] = useState<Location | null>(null);
@@ -663,14 +665,14 @@ const Create = () => {
                 clearTrigger={clearLocationTrigger}
               />
 
-              {location?.latitude && location?.longitude && (
+              {location?.coordinates?.coordinates?.[0] && location?.coordinates?.coordinates?.[1] && (
                 <View
-                  key={`${location.latitude}-${location.longitude}`}
+                  key={`${location.coordinates.coordinates[0]}-${location.coordinates.coordinates[1]}`}
                   style={styles.mapContainer}
                 >
                   <EventLocationMap
-                    latitude={parseFloat(location.latitude)}
-                    longitude={parseFloat(location.longitude)}
+                    latitude={location.coordinates.coordinates[1]}
+                    longitude={location.coordinates.coordinates[0]}
                   />
                 </View>
               )}

--- a/ClientApp/app/(tabs)/home/searchPage.tsx
+++ b/ClientApp/app/(tabs)/home/searchPage.tsx
@@ -33,6 +33,7 @@ export default function searchPage() {
   const [results, setResults] = useState<Profile[]>([]);
   const [cancel, setCancel] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [viewMode, setViewMode] = useState<"map" | "list">("list");
 
   const location = useSelector((state: { location: Location.LocationObjectCoords | null }) => state.location);
   const [userLocation, setUserLocation] = useState<Location.LocationObjectCoords | null>(location);
@@ -116,8 +117,7 @@ export default function searchPage() {
     const [loading, setLoading] = useState(false);
     const router = useRouter();
     const mapRef = useRef<MapView | null>(null);
-    const [isMapExpanded, setIsMapExpanded] = useState(false);
-    const [viewMode, setViewMode] = useState<"map" | "list">("list");
+    const [isMapExpanded, setIsMapExpanded] = useState(viewMode === "map");;
 
     useEffect(() => {
       const fetchEvents = async () => {
@@ -172,14 +172,17 @@ export default function searchPage() {
       }
     };
 
+    const handleToggleViewMode = () => {
+      const newMode = viewMode === "map" ? "list" : "map";
+      setViewMode(newMode);
+      setIsMapExpanded(newMode === "map");
+    };
+
     return (
       <View style={{ flex: 1 }}>
         <TouchableOpacity
           style={styles.toggleButton}
-          onPress={() => {
-            setViewMode(viewMode === "map" ? "list" : "map");
-            setIsMapExpanded(!isMapExpanded);
-          }}
+          onPress={handleToggleViewMode}
         >
           <MaterialCommunityIcons
             name={viewMode === "map" ? "format-list-bulleted" : "map"}

--- a/ClientApp/app/(tabs)/home/searchPage.tsx
+++ b/ClientApp/app/(tabs)/home/searchPage.tsx
@@ -490,11 +490,11 @@ const styles = StyleSheet.create({
   },
   centerButton: {
     position: "absolute",
-    top: Platform.OS === "ios" ? 470 : 360,
+    top: Platform.OS === "ios" ? vs(400) : vs(380),
     right: 20,
     backgroundColor: themeColors.primary,
     paddingVertical: 10,
-    paddingHorizontal: 15,
+    paddingHorizontal: 10,
     borderRadius: 20,
     flexDirection: "row",
     alignItems: "center",

--- a/ClientApp/app/(tabs)/home/searchPage.tsx
+++ b/ClientApp/app/(tabs)/home/searchPage.tsx
@@ -183,12 +183,12 @@ export default function searchPage() {
             color="white"
           />
         </TouchableOpacity>
-
         <MapView
           // mapType="hybrid"
+          showsMyLocationButton = {false}
           showsUserLocation
           ref={mapRef}
-          style={{ flex: isMapExpanded ? 1 : 0.3 }}
+          style={{ flex: isMapExpanded ? 1 : 0.3, margin: isMapExpanded ? 0 : 10 }}
           initialRegion={
             userLocation
             ? {
@@ -535,7 +535,7 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     paddingVertical: 8,
-    paddingHorizontal: 12,
+    paddingHorizontal: 8,
     borderRadius: 20,
     zIndex: 10,
     elevation: 5,
@@ -544,4 +544,7 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.2,
     shadowRadius: 5,
   },
+  mapView: {
+    padding: 1,
+  }
 });

--- a/ClientApp/app/(tabs)/home/searchPage.tsx
+++ b/ClientApp/app/(tabs)/home/searchPage.tsx
@@ -189,16 +189,25 @@ export default function searchPage() {
           showsUserLocation
           ref={mapRef}
           style={{ flex: isMapExpanded ? 1 : 0.3 }}
-          initialRegion={{
-            latitude: events.length && events[0].locationResponse.coordinates?.y !== undefined
-              ? Number(events[0].locationResponse.coordinates.y)
-              : 45.5017,
-            longitude: events.length && events[0].locationResponse.coordinates?.x !== undefined
-              ? Number(events[0].locationResponse.coordinates.x)
-              : -73.5673,
-            latitudeDelta: 0.1,
-            longitudeDelta: 0.1,
-          }}
+          initialRegion={
+            userLocation
+            ? {
+                latitude: userLocation.latitude,
+                longitude: userLocation.longitude,
+                latitudeDelta: 0.05,
+                longitudeDelta: 0.05,
+              }
+            : {
+                latitude: events.length && events[0].locationResponse.coordinates?.y !== undefined
+                  ? Number(events[0].locationResponse.coordinates.y)
+                  : 45.5017,
+                longitude: events.length && events[0].locationResponse.coordinates?.x !== undefined
+                  ? Number(events[0].locationResponse.coordinates.x)
+                  : -73.5673,
+                latitudeDelta: 0.1,
+                longitudeDelta: 0.1,
+              }
+            }
         >
           {events.map((event) => (
             <Marker

--- a/ClientApp/app/(tabs)/home/searchPage.tsx
+++ b/ClientApp/app/(tabs)/home/searchPage.tsx
@@ -133,8 +133,8 @@ export default function searchPage() {
     const onEventCardPress = (event: Event) => {
       mapRef.current?.animateToRegion(
         {
-          latitude: Number(event.locationResponse.coordinates?.y),
-          longitude: Number(event.locationResponse.coordinates?.x),
+          latitude: Number(event.locationResponse.coordinates?.coordinates?.[1]),
+          longitude: Number(event.locationResponse.coordinates?.coordinates?.[0]),
           latitudeDelta: 0.05,
           longitudeDelta: 0.05,
         },
@@ -198,11 +198,11 @@ export default function searchPage() {
                 longitudeDelta: 0.05,
               }
             : {
-                latitude: events.length && events[0].locationResponse.coordinates?.y !== undefined
-                  ? Number(events[0].locationResponse.coordinates.y)
+                latitude: events.length && events[0].locationResponse.coordinates?.coordinates?.[1] !== undefined
+                  ? Number(events[0].locationResponse.coordinates.coordinates[1])
                   : 45.5017,
-                longitude: events.length && events[0].locationResponse.coordinates?.x !== undefined
-                  ? Number(events[0].locationResponse.coordinates.x)
+                longitude: events.length && events[0].locationResponse.coordinates?.coordinates?.[0] !== undefined
+                  ? Number(events[0].locationResponse.coordinates.coordinates[0])
                   : -73.5673,
                 latitudeDelta: 0.1,
                 longitudeDelta: 0.1,
@@ -213,8 +213,8 @@ export default function searchPage() {
             <Marker
               key={event.id}
               coordinate={{
-                latitude: event.locationResponse.coordinates?.y ? Number(event.locationResponse.coordinates.y) : 0,
-                longitude: event.locationResponse.coordinates?.x ? Number(event.locationResponse.coordinates.x) : 0,
+                latitude: event.locationResponse.coordinates?.coordinates?.[1] ? Number(event.locationResponse.coordinates.coordinates[1]) : 0,
+                longitude: event.locationResponse.coordinates?.coordinates?.[0] ? Number(event.locationResponse.coordinates.coordinates[0]) : 0,
               }}
               title={event.eventName}
               onPress={() => handleEventPress(event.id)}
@@ -274,8 +274,8 @@ export default function searchPage() {
             <TouchableOpacity 
               style={styles.navigateButton} 
               onPress={() => {
-                const latitude = Number(event.locationResponse.coordinates?.y);
-                const longitude = Number(event.locationResponse.coordinates?.x);
+                const latitude = Number(event.locationResponse.coordinates?.coordinates?.[1]);
+                const longitude = Number(event.locationResponse.coordinates?.coordinates?.[0]);
                 if (!isNaN(latitude) && !isNaN(longitude)) {
                   openNavigation(latitude, longitude);
                 }
@@ -529,8 +529,8 @@ const styles = StyleSheet.create({
   },
   toggleButton: {
     position: "absolute",
-    top: 10,
-    right: 10,
+    top: 20,
+    right: 20,
     backgroundColor: themeColors.primary,
     flexDirection: "row",
     alignItems: "center",

--- a/ClientApp/app/events/[eventId].tsx
+++ b/ClientApp/app/events/[eventId].tsx
@@ -27,13 +27,6 @@ const EventPosts = () => {
 const EventDetails = ({ event, handleJoinEvent }: { event: Event; handleJoinEvent: () => void }) => {
   const router = useRouter();
   const user = useSelector((state: { user: any }) => state.user);
-  const { eventId } = useLocalSearchParams<{ eventId: string }>();
-  const currentLongitude = -73.5673;
-  const currentLatitude = 45.5017;
-
-  console.log("current longitude", currentLongitude);
-  console.log("current latitude", currentLatitude);
-  console.log("event location", event.locationResponse);
 
   return (
     <ScrollView contentContainerStyle={styles.container}>
@@ -92,11 +85,11 @@ const EventDetails = ({ event, handleJoinEvent }: { event: Event; handleJoinEven
       </View>
       
       {/* Event Location Map */}
-      {event.locationResponse?.coordinates?.y && event.locationResponse?.coordinates?.x && (
+      {event.locationResponse?.coordinates?.coordinates?.[1] && event.locationResponse?.coordinates?.coordinates?.[0] && (
         <View style={styles.section}>
           <EventLocationMap 
-            latitude={event.locationResponse.coordinates.y} 
-            longitude={event.locationResponse.coordinates.x} 
+            latitude={event.locationResponse.coordinates.coordinates[1]} 
+            longitude={event.locationResponse.coordinates.coordinates[0]}
             showFullScreenButton={false}
           />
         </View>

--- a/ClientApp/app/events/[eventId].tsx
+++ b/ClientApp/app/events/[eventId].tsx
@@ -28,7 +28,13 @@ const EventDetails = ({ event, handleJoinEvent }: { event: Event; handleJoinEven
   const router = useRouter();
   const user = useSelector((state: { user: any }) => state.user);
   const { eventId } = useLocalSearchParams<{ eventId: string }>();
-  
+  const currentLongitude = -73.5673;
+  const currentLatitude = 45.5017;
+
+  console.log("current longitude", currentLongitude);
+  console.log("current latitude", currentLatitude);
+  console.log("event location", event.locationResponse);
+
   return (
     <ScrollView contentContainerStyle={styles.container}>
       {/* Description */}
@@ -86,11 +92,11 @@ const EventDetails = ({ event, handleJoinEvent }: { event: Event; handleJoinEven
       </View>
       
       {/* Event Location Map */}
-      {event.locationResponse?.latitude && event.locationResponse?.longitude && (
+      {event.locationResponse?.coordinates?.y && event.locationResponse?.coordinates?.x && (
         <View style={styles.section}>
           <EventLocationMap 
-            latitude={parseFloat(event.locationResponse.latitude)} 
-            longitude={parseFloat(event.locationResponse.longitude)} 
+            latitude={event.locationResponse.coordinates.y} 
+            longitude={event.locationResponse.coordinates.x} 
             showFullScreenButton={false}
           />
         </View>

--- a/ClientApp/components/Helper Components/GooglePlacesInput.tsx
+++ b/ClientApp/components/Helper Components/GooglePlacesInput.tsx
@@ -16,8 +16,10 @@ interface LocationData {
   province: string;
   country: string;
   postalCode: string;
-  latitude: string;
-  longitude: string;
+  coordinates: {
+    coordinates: [number, number];
+    type: string;
+  }
 }
 
 const GooglePlacesInput: React.FC<GooglePlacesInputProps> = ({
@@ -68,8 +70,10 @@ const GooglePlacesInput: React.FC<GooglePlacesInputProps> = ({
                 details.address_components.find((comp) =>
                   comp.types.includes("postal_code")
                 )?.long_name || "",
-              latitude: details.geometry.location.lat.toString(),
-              longitude: details.geometry.location.lng.toString(),
+              coordinates: {
+                coordinates: [details.geometry.location.lng, details.geometry.location.lat] as [number, number],
+                type: "Point",
+              },
             };
 
             setSelectedLocation(locationData);

--- a/ClientApp/types/event.ts
+++ b/ClientApp/types/event.ts
@@ -26,8 +26,6 @@ export interface Event {
       addressLine2?: string; 
       phoneNumber?: string; 
       coordinates?: {
-        x: number;
-        y: number;
         coordinates: number[];
         type: string;
       }

--- a/ClientApp/types/event.ts
+++ b/ClientApp/types/event.ts
@@ -25,8 +25,12 @@ export interface Event {
       postalCode: string; 
       addressLine2?: string; 
       phoneNumber?: string; 
-      latitude?: string; 
-      longitude?: string; 
+      coordinates?: {
+        x: number;
+        y: number;
+        coordinates: number[];
+        type: string;
+      }
     };
     createdBy: string; 
     teams?: {

--- a/ClientApp/utils/api/eventApiClient.ts
+++ b/ClientApp/utils/api/eventApiClient.ts
@@ -28,3 +28,15 @@ export async function getEventById(eventId: string): Promise<Event> {
       throw error.response?.data || error;
     }
   }
+
+
+  export async function getAllEvents(): Promise<Event[]> {
+    const axiosInstance = getAxiosInstance();
+    try {
+      const response = await axiosInstance.get<Event[]>(API_ENDPOINTS.GET_ALL_EVENTS);
+      return response.data;
+    } catch (error: any) {
+      console.error("Error fetching events:", error);
+      throw error.response?.data || error;
+    }
+  }


### PR DESCRIPTION
### Note:
This PR includes all the UI for search events without any search functionality until implemented later.

### Changes:
- Add map view of events when searching for events.
- Add list view of events (reused component).
- Add toggle button between map view and list view.
- Match updates in the event model that were made in #366.

### Demo steps:
1. Login
2. Allow location access (ensure it's enabled in the simulator)
3. Press on the search icon located top right on the header of home page
4. Toggle "Events" tab

### Events to use for testing:
- Montreal Tech Conference1
- Montreal Tech Conference3
- Montreal Tech Conference4
- Youssef march6 test5

### What to test (answer must be YES to all):
- Can you toggle between list view and map view without issues?
- Does list view contain events?
- Does map view contain events?
- Does map view show markers for event locations?
- When pressing on an event, do you get redirected to either the event's page or  location?

### Screenshots
#### List view of events
![image](https://github.com/user-attachments/assets/5b3ba7b5-a150-487c-bc00-72788a3cd425)

#### Map view of events with horizontal events list
![image](https://github.com/user-attachments/assets/f18a0c9b-11db-4121-8609-1994b82f86e7)

#### Press on an event card from the list above -> map is animated to the event's actual location
![image](https://github.com/user-attachments/assets/03cd2949-7645-4b43-83e3-b1a1570d8cb6)