### PR TITLE
GH-386: [bug] Fixes for QR UI and event service filtering

### DIFF
--- a/ClientApp/components/QR/QR.tsx
+++ b/ClientApp/components/QR/QR.tsx
@@ -29,16 +29,25 @@ const QR: React.FC<QRProps> = ({ id, isVisible, setIsVisible, isProfile }) => {
     Linking.canOpenURL("myapp://").then((result) => setCanOpenLink(true));
   }, []);
   const logo = require("@/assets/images/sporta_logo.png");
-  const userURL = isProfile && id ? deepLinks.Profile.replace("{id}", id): deepLinks.Event.replace("{id}", id);
- 
+  const userURL =
+    isProfile && id
+      ? deepLinks.Profile.replace("{id}", id)
+      : deepLinks.Event.replace("{id}", id);
+
   return (
-    <BottomModal isVisible={isVisible} setIsVisible={setIsVisible} height={undefined}>
-      <QRCode value={userURL} size={250} logo={logo} testID="QRCode" />
-            <View style={styles.closeButton}>
-              <Text style={styles.closeButtonText}>
-                Share your {isProfile ? "profile" : "event"} with friends
-              </Text>
-            </View>
+    <BottomModal
+      isVisible={isVisible}
+      setIsVisible={setIsVisible}
+      height={undefined}
+    >
+      <View>
+        <QRCode value={userURL} size={250} logo={logo} testID="QRCode" />
+        <View style={styles.closeButton}>
+          <Text style={styles.closeButtonText}>
+            Share your {isProfile ? "profile" : "event"} with friends
+          </Text>
+        </View>
+      </View>
     </BottomModal>
   );
 };

--- a/ClientApp/services/eventService.ts
+++ b/ClientApp/services/eventService.ts
@@ -2,6 +2,7 @@ import { FilterState } from "@/components/Helper Components/FilterSection/Filter
 import { getAxiosInstance } from "@/services/axiosInstance";
 import { API_ENDPOINTS } from "@/utils/api/endpoints";
 import { accessibilityProps } from "react-native-paper/lib/typescript/components/MaterialCommunityIcon";
+
 //API_ENDPOINTS.CREATE_EVENT
 export const createEvent = async (eventData: any) => {
   try {
@@ -110,11 +111,14 @@ export const searchEventsWithFilter = async (
       queryParams.requiredSkillLevel = params.skillLevel.toUpperCase();
     }
 
-    //queryParams.date = addAdjustedDate(params);
+    if(params.minDate !== params.maxDate){
+      queryParams.date = addAdjustedDate(params);
+    }
     
     if (params.filterType !== "All") {
       queryParams.sportType = params.filterType;
     }
+
     if (Object.keys(queryParams).length > 0) {
       const response = axiosInstance.get(endpoint, {
         params: queryParams,
@@ -131,16 +135,19 @@ export const searchEventsWithFilter = async (
 };
 
 const addAdjustedDate = (params: FilterState) => {
+  const minMonth = params.minDate.getMonth() <= 9 ? "0" + params.minDate.getMonth() : params.minDate.getMonth();
+  const maxMonth = params.maxDate.getMonth() <= 9 ? "0" + params.maxDate.getMonth() : params.maxDate.getMonth();
+  
   const minDate =
     params.minDate.getFullYear() +
     "-" +
-    params.minDate.getMonth() +
+    minMonth +
     "-" +
     params.minDate.getDate();
   const maxDate =
     params.maxDate.getFullYear() +
     "-" +
-    params.maxDate.getMonth() +
+    maxMonth +
     "-" +
     params.maxDate.getDate();
 


### PR DESCRIPTION
### This PR includes:
- Fix for the QR code displaying cannot have react.children inside bottomModal
- Implements the event filtering upon date functionality in the frontend

Test:
- For QR, simply go to profile or event and press on display QR code to share either event/profile and modal should appear with no error
- For filtering, select any two dates between a date range and see the events appear accordingly