### PR TITLE
GH-388: [feat] implement app splash screen and logo

### DIFF
--- a/ClientApp/app.json
+++ b/ClientApp/app.json
@@ -4,11 +4,11 @@
     "slug": "ClientApp",
     "version": "1.0.0",
     "orientation": "portrait",
-    "icon": "./assets/images/icon.png",
+    "icon": "./assets/images/sporta_logo.png",
     "scheme": "myapp",
     "userInterfaceStyle": "automatic",
     "splash": {
-      "image": "./assets/images/splash.png",
+      "image": "./assets/images/sporta_logo.png",
       "resizeMode": "contain",
       "backgroundColor": "#ffffff"
     },
@@ -24,7 +24,7 @@
     },
     "android": {
       "adaptiveIcon": {
-        "foregroundImage": "./assets/images/adaptive-icon.png",
+        "foregroundImage": "./assets/images/sporta_logo.png",
         "backgroundColor": "#ffffff"
       },
       "softwareKeyboardLayoutMode": "pan",


### PR DESCRIPTION
### Description:

The app now has a unique splash screen and logo displayed that users can see. The user is now able to locate the app easier. Also when opened, the app displayed its splash screen enhancing the credibility of the team and app.

Refrences:
<img width="287" alt="image" src="https://github.com/user-attachments/assets/21430194-0509-41ee-b944-024662ac8a50" />
<img width="306" alt="image" src="https://github.com/user-attachments/assets/317f5a3b-92c0-4cff-8149-0bc17e3fe435" />
