### PR TITLE
GH-390: [fix] restrict post creation to only joined users and UI improvement

### DIFF
--- a/ClientApp/app/events/[eventId].tsx
+++ b/ClientApp/app/events/[eventId].tsx
@@ -17,14 +17,6 @@ import Octicons from '@expo/vector-icons/Octicons';
 import * as Clipboard from 'expo-clipboard';
 import EventPostsTab from "@/components/Event/EventPostsTab";
 
-const EventPosts = () => {
-  return (
-    <View>
-      <Text>Event Posts</Text>
-    </View>
-  );
-}
-
 const EventDetails = ({ event, handleJoinEvent }: { event: Event; handleJoinEvent: () => void }) => {
   const router = useRouter();
   const user = useSelector((state: { user: any }) => state.user);
@@ -186,7 +178,7 @@ const EventPage: React.FC = () => {
   ];
   
   const scenes = {
-    eventPosts: [<EventPostsTab eventId={eventId} key={eventId} />],
+    eventPosts: [<EventPostsTab eventId={eventId} key={eventId} isUserParticipant={isUserParticipant}/>],
     eventDetails: <EventDetails event={event} handleJoinEvent={handleJoinEvent} />,
   };
 

--- a/ClientApp/components/Event/EventPostsTab.tsx
+++ b/ClientApp/components/Event/EventPostsTab.tsx
@@ -7,7 +7,7 @@ import { Post } from '@/types/post';
 import { getProfile } from '@/utils/api/profileApiClient';
 import { mhs, mvs } from '@/utils/helpers/uiScaler';
 
-const EventPostsTab = ({ eventId }: { eventId: string }) => {
+const EventPostsTab = ({ eventId, isUserParticipant }: { eventId: string, isUserParticipant: boolean }) => {
     const [posts, setPosts] = useState<Post[]>([]);
     const [userProfiles, setUserProfiles] = useState<{ [userId: string]: any }>({});
     const [loading, setLoading] = useState<boolean>(true);
@@ -94,16 +94,23 @@ const EventPostsTab = ({ eventId }: { eventId: string }) => {
                 onScroll={handleScroll}
                 scrollEventThrottle={16}
             >
-                <PostCreationComponent eventId={eventId} onNewPost={handleNewPost} />
+                {isUserParticipant && <PostCreationComponent eventId={eventId} onNewPost={handleNewPost} />}
                 <View style={{ height: 16 }} />
-                {posts.map((post) => (
-                    <PostComponent key={post.id} post={post} userProfile={userProfiles[post.createdBy]} />
-                ))}
+    
+                {posts.length === 0 ? (
+                    <Text style={styles.noPostsText}>Be the first one to post!</Text>
+                ) : (
+                    posts.map((post) => (
+                        <PostComponent key={post.id} post={post} userProfile={userProfiles[post.createdBy]} />
+                    ))
+                )}
+    
                 {loading && <ActivityIndicator size="small" color="#0000ff" />}
-                {!hasMore && <Text style={styles.noMorePostsText}>You have reached the end!</Text>}
+                {posts.length > 0 && !hasMore && <Text style={styles.noMorePostsText}>You have reached the end!</Text>}
             </ScrollView>
         </SafeAreaView>
     );
+    
 };
 
 const styles = StyleSheet.create({
@@ -111,6 +118,11 @@ const styles = StyleSheet.create({
         flex: 1,
         padding: mhs(16),
         backgroundColor: '#fafafa',
+    },
+    noPostsText: {
+        textAlign: 'center',
+        marginVertical: mvs(12),
+        color: '#888',
     },
     noMorePostsText: {
         textAlign: 'center',


### PR DESCRIPTION
### Description
- Post creation option is now restricted for only joined users of an event.
- Not all users will see the create post option.
- Small UI improvement to display different fallback messages where there are no posts to display or when the user has reached the end when displaying posts.

References:
<img width="305" alt="image" src="https://github.com/user-attachments/assets/22ea16d5-25f3-4b25-a682-d732a75d636e" /><img width="402" alt="image" src="https://github.com/user-attachments/assets/b6a9a866-b51c-4b7f-91ad-20e0aa63da9e" />
<img width="310" alt="image" src="https://github.com/user-attachments/assets/f3666f19-51af-414e-a1ce-d5e25b35f73b" />

