### PR TITLE
GH-403: [fix] Posts display access error fix

### DIFF
--- a/ClientApp/utils/api/endpoints.tsx
+++ b/ClientApp/utils/api/endpoints.tsx
@@ -26,6 +26,7 @@ export const API_ENDPOINTS = {
   GET_ALL_FRIENDS: 'user-service/user/{userId}/friends',
   RESPOND_TO_FRIEND_REQUEST: 'user-service/user/{userId}/friend-requests/{requestId}',
   GET_PROFILE_BY_ID: 'user-service/user/{userId}/profile',
+  GET_PUBLIC_PROFILE:  'user-service/user/{userId}/profile',
 
   GET_ALL_POSTS: "event-service/event/{eventId}/social/post",
   CREATE_POST: "event-service/event/{eventId}/social/post",

--- a/ClientApp/utils/api/profileApiClient.ts
+++ b/ClientApp/utils/api/profileApiClient.ts
@@ -18,7 +18,7 @@ export async function registerProfile(profile: Profile, userId: string) {
 export async function getProfile(userId: string) {
     const axiosInstance = getAxiosInstance();
     try {
-        const response = await axiosInstance.get<Profile>(API_ENDPOINTS.GET_USER_BY_ID.replace('{id}', userId));
+        const response = await axiosInstance.get<Profile>(API_ENDPOINTS.GET_PUBLIC_PROFILE.replace('{userId}', userId));
         return response.data
     } catch (error: any) {
         console.error('Error fetching profile:', error);


### PR DESCRIPTION
### Description
The logged in user can now see the posts that other people have made in any event page.
<img width="302" alt="image" src="https://github.com/user-attachments/assets/334d4fdd-ab7b-413e-9f4c-8d64c5dc048c" />
