### PR TITLE
GH-408: [Bug] Fixed iPhone camera issue when posting an event

### DIFF
--- a/ClientApp/app.json
+++ b/ClientApp/app.json
@@ -16,11 +16,15 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.nchelico.ClientApp",
-      "infoPlist": {
-        "ITSAppUsesNonExemptEncryption": false,
-        "LSApplicationQueriesSchemes": [
-          "myapp"
-        ]
+     "infoPlist": {
+      "ITSAppUsesNonExemptEncryption": false,
+      "NSCameraUsageDescription": "This app needs access to your camera to take photos.",
+      "NSMicrophoneUsageDescription": "This app needs access to your microphone for video recording.",
+      "NSPhotoLibraryUsageDescription": "This app needs access to your photo library to upload images.",
+      "NSPhotoLibraryAddUsageDescription": "This app needs permission to save photos to your gallery.",
+      "LSApplicationQueriesSchemes": [
+        "myapp"
+      ]
       },
       "config": {
         "googleMapsApiKey":  "process.env.GOOGLE_MAPS_API_KEY"

--- a/ClientApp/components/Posts/PostCreationComponent.tsx
+++ b/ClientApp/components/Posts/PostCreationComponent.tsx
@@ -49,10 +49,11 @@ const PostCreationComponent: React.FC<PostCreationProps> = ({ eventId, onNewPost
         return;
       }
       result = await ImagePicker.launchImageLibraryAsync({
-        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        mediaTypes: ["images"],
         allowsEditing: false,
         quality: 1,
       });
+      
     } else if (source === 'camera') {
       const { status } = await Camera.requestCameraPermissionsAsync();
       if (status !== 'granted') {
@@ -61,7 +62,7 @@ const PostCreationComponent: React.FC<PostCreationProps> = ({ eventId, onNewPost
       }
   
       result = await ImagePicker.launchCameraAsync({
-        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        mediaTypes: ["images"],
         allowsEditing: false,
         quality: 1,
       });

--- a/ClientApp/package.json
+++ b/ClientApp/package.json
@@ -103,7 +103,8 @@
     "react-native-vector-icons": "^10.2.0",
     "react-native-web": "~0.19.10",
     "react-redux": "^9.1.2",
-    "tailwindcss": "^3.4.14"
+    "tailwindcss": "^3.4.14",
+    "expo-camera": "~16.0.18"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",


### PR DESCRIPTION
Fixed the iPhone camera issue when posting an event by adding proper camera permissions and updating expo-image-picker API usage. Tested on iOS to ensure the camera opens and attaches images correctly.