### PR TITLE
Hotfix - return empty list of events rather than 404 for location based retrieval

### DIFF
--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/service/event/EventServiceImpl.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/service/event/EventServiceImpl.java
@@ -106,10 +106,6 @@ public class EventServiceImpl implements EventService {
             events = eventRepository.findByLocationCoordinatesNear(point, distance, pageable);
         }
 
-        if(events.isEmpty()){
-            throw new EventsNotFoundException();
-        }
-
         return ResponseEntity.ok(paginate ? events.map(eventMapper::eventToEventResponse):
                 events.getContent().stream().map(eventMapper::eventToEventResponse).toList());
     }

--- a/Microservices/event-service/src/test/java/app/sportahub/eventservice/service/event/EventServiceTest.java
+++ b/Microservices/event-service/src/test/java/app/sportahub/eventservice/service/event/EventServiceTest.java
@@ -205,26 +205,6 @@ class EventServiceTest {
     }
 
     @Test
-    public void testGetRelevantEvents_EmptyResult() {
-        when(eventRepository.findByLocationCoordinatesNear(any(GeoJsonPoint.class), any(Distance.class), any(Pageable.class)))
-                .thenReturn(Page.empty());
-
-        assertThrows(EventsNotFoundException.class, () -> {
-            eventServiceImpl.getRelevantEvents(0.0, 0.0, 10.0, false, true, 0, 10);
-        });
-    }
-
-    @Test
-    public void testGetRelevantEventsWithExpandedRadius_EmptyResult() {
-        when(eventRepository.findByLocationCoordinatesNear(any(GeoJsonPoint.class), any(Distance.class), any(Pageable.class)))
-                .thenReturn(Page.empty());
-
-        assertThrows(EventsNotFoundException.class, () -> {
-            eventServiceImpl.getRelevantEvents(0.0, 0.0, 10.0, true, true, 0, 10);
-        });
-    }
-
-    @Test
     void getRelevantEventsShouldExpandRadiusAndReturnEvents() {
         GeoJsonPoint point = new GeoJsonPoint(0, 0);
         Distance initialDistance = new Distance(25, Metrics.KILOMETERS);


### PR DESCRIPTION
This hotfix removes the `EventsNotFound` exception that is thrown when no events are found based on the location search criteria, from now on it will return an empty list instead. 