### PR TITLE
Feat/issue 413/cancel event

### DIFF
--- a/ClientApp/app/events/[eventId].tsx
+++ b/ClientApp/app/events/[eventId].tsx
@@ -215,10 +215,19 @@ const EventPage: React.FC = () => {
     <SafeAreaView className="flex-1 bg-white pt-6">
       <View style={styles.header}>
         <View style={styles.headerTextContainer}>
-          <View style={styles.eventTitle}>
-            <Text style={styles.eventName}>{event.eventName}</Text>
-          </View>
-          <View style={styles.details}>
+        <View style={styles.eventTitle}>
+        <Text
+  style={[
+    styles.eventName,
+    event.cancellation && { color: "red" }, 
+  ]}
+>
+  {event.eventName}
+  {event.cancellation && " (Cancelled)"}
+</Text>
+</View>
+
+    <View style={styles.details}>
             <Text style={styles.detailText}>
               <FontAwesome6 name="map-pin" size={16} color="black" />{" "}
               {event.locationResponse?.streetNumber} {event.locationResponse?.streetName}, {event.locationResponse?.city}

--- a/ClientApp/app/events/[eventId].tsx
+++ b/ClientApp/app/events/[eventId].tsx
@@ -226,7 +226,6 @@ const EventPage: React.FC = () => {
   {event.cancellation && " (Cancelled)"}
 </Text>
 </View>
-
     <View style={styles.details}>
             <Text style={styles.detailText}>
               <FontAwesome6 name="map-pin" size={16} color="black" />{" "}

--- a/ClientApp/app/events/_layout.tsx
+++ b/ClientApp/app/events/_layout.tsx
@@ -4,7 +4,7 @@ import { router, Stack } from "expo-router";
 import { Menu, Provider } from "react-native-paper";
 import { Ionicons, MaterialCommunityIcons } from "@expo/vector-icons";
 import themeColors from "@/utils/constants/colors";
-import { deleteEvent, getEventDetails, leaveEvent } from "@/services/eventService";
+import { deleteEvent, getEventDetails, leaveEvent, cancelEvent } from "@/services/eventService";
 import { useLocalSearchParams } from "expo-router";
 import QR from "@/components/QR/QR";
 import { mvs } from "@/utils/helpers/uiScaler";
@@ -79,6 +79,9 @@ export default function EventDetailsLayout() {
       case "delete":
         handleDeleteEvent(eventId);
         break;
+        case "cancel":
+      handleCancelEvent(eventId);
+       break;
       default:
         break;
     }
@@ -122,6 +125,42 @@ export default function EventDetailsLayout() {
         },
       },
     ]);
+  };
+
+  const handleCancelEvent = async (eventId: string | undefined) => {
+    if (!eventId) {
+      Alert.alert("Error", "Event ID is missing.");
+      return;
+    }
+  
+    Alert.prompt(
+      "Cancel Event",
+      "Please provide a reason for cancelling this event:",
+      [
+        {
+          text: "Cancel",
+          style: "cancel",
+        },
+        {
+          text: "Confirm",
+          onPress: async (reason) => {
+            if (!reason) {
+              Alert.alert("Error", "A reason is required to cancel the event.");
+              return;
+            }
+  
+            try {
+              await cancelEvent(eventId, reason);
+              Alert.alert("Success", "Event has been cancelled.");
+              router.replace("/(tabs)/home");
+            } catch (error) {
+              Alert.alert("Error", "Unable to cancel event.");
+            }
+          },
+        },
+      ],
+      "plain-text"
+    );
   };
   
   const handleDeleteEvent = async (eventId: string | undefined) => {
@@ -189,6 +228,7 @@ export default function EventDetailsLayout() {
   {isCreator && (
     <React.Fragment>
       <Menu.Item onPress={() => handleOptionPress("edit")} title={t('event_details_layout.edit_event')} />
+      <Menu.Item onPress={() => handleOptionPress("cancel")} title="Cancel Event" titleStyle={{ color: "orange" }} />
       <Menu.Item onPress={() => handleOptionPress("delete")} title={t('event_details_layout.delete_event')} titleStyle={{ color: "red" }} />
     </React.Fragment>
   )}

--- a/ClientApp/components/Event/EventCard.tsx
+++ b/ClientApp/components/Event/EventCard.tsx
@@ -134,8 +134,8 @@ const locale = i18n.language === 'fr' ? 'fr' : 'en';
 >
   {event.eventName}
   {event.cancellation && " (Cancelled)"}
-</Text>
- {showDetailPreview &&(
+    </Text>
+    {showDetailPreview &&(
           <Text style={styles.eventDetails}>
             {isForVisitedProfile
           ? `${event.sportType}`
@@ -144,7 +144,6 @@ const locale = i18n.language === 'fr' ? 'fr' : 'en';
             : `${event.far} ${t('event_card.km_away')}`}
         </Text>
     )}
-
       {showSportType &&
         <View style={styles.sportIconContainer}>
           <MaterialCommunityIcons

--- a/ClientApp/components/Event/EventCard.tsx
+++ b/ClientApp/components/Event/EventCard.tsx
@@ -126,8 +126,16 @@ const locale = i18n.language === 'fr' ? 'fr' : 'en';
 
   return (
     <TouchableOpacity testID='event-card' style={[styles.card, dynamicCardStyle]} onPress={() => onPress(event.id)}>
-      <Text style={styles.eventName}>{event.eventName}</Text>
-      {showDetailPreview &&(
+      <Text
+  style={[
+    styles.eventName,
+    event.cancellation && { color: "red" }
+  ]}
+>
+  {event.eventName}
+  {event.cancellation && " (Cancelled)"}
+</Text>
+ {showDetailPreview &&(
           <Text style={styles.eventDetails}>
             {isForVisitedProfile
           ? `${event.sportType}`

--- a/ClientApp/services/eventService.ts
+++ b/ClientApp/services/eventService.ts
@@ -311,3 +311,18 @@ export const getEventById = async (eventId: string) => {
     throw error;
   }
 }
+export const cancelEvent = async (eventId: string, reason: string) => {
+  try {
+    const axiosInstance = getAxiosInstance();
+    const response = await axiosInstance.patch(
+      API_ENDPOINTS.CANCEL_EVENT_BY_ID.replace("{id}", eventId),
+      {
+        reason: reason, 
+      }
+    );
+    return response.data;
+  } catch (error) {
+    console.error("Error cancelling event:", error);
+    throw error;
+  }
+};

--- a/ClientApp/types/event.ts
+++ b/ClientApp/types/event.ts
@@ -39,4 +39,9 @@ export interface Event {
   isPrivate: boolean;
   whitelistedUsers?: string[];
   far: number;
+  cancellation?: {
+    cancelledAt: string;
+    cancelledBy: string;
+    reason: string;
+  };
 }

--- a/ClientApp/utils/api/endpoints.tsx
+++ b/ClientApp/utils/api/endpoints.tsx
@@ -22,6 +22,7 @@ export const API_ENDPOINTS = {
   SEARCH_EVENTS:"event-service/event/search",
   LEAVE_EVENT: "event-service/event/{id}/leave",
   EDIT_EVENT_BY_ID: 'event-service/event/{id}',
+  CANCEL_EVENT_BY_ID: "event-service/event/{id}/cancel",
 
 
   SEND_FRIEND_REQUEST: 'user-service/user/{userId}/friends/requests',


### PR DESCRIPTION

Integrated event cancellation functionality:

- Creators can now cancel events with a reason.
- Cancelled events are marked as (Cancelled) in both the event page and homepage feed.
- Removed cancellation reason display from the UI for better UX.

![image](https://github.com/user-attachments/assets/19ae4512-d4a4-48ee-ad6d-60175360ea93)

![image](https://github.com/user-attachments/assets/114f2459-8271-4f5e-8635-fbaf669e6e5e)


