### PR TITLE
[BUG] Storage Service Size Limit Too Low

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 node_modules/
 .expo/
 .idea/
+
+### VS Code ###
 .vscode/
+
 # macOS
 .DS_Store
 ClientApp/package-lock.json
@@ -9,3 +12,38 @@ ClientApp/package-lock.json
 ClientApp/coverage
 
 sports-app.code-workspace
+
+HELP.md
+.gradle
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/

--- a/Microservices/storage-service/src/main/resources/application.properties
+++ b/Microservices/storage-service/src/main/resources/application.properties
@@ -55,5 +55,10 @@ minio.access.secret=${MINIO_CLIENT_SECRET}
 minio.url=${MINIO_URL}
 minio.bucket.name=${MINIO_BUCKET}
 
+# Multipart Properties
+spring.servlet.multipart.max-file-size=10GB
+spring.servlet.multipart.max-request-size=10GB
+
+# Logstash Properties
 logging.logstash.host=${LOGSTASH_HOST:localhost}
 logging.logstash.port=${LOGSTASH_PORT:5044}


### PR DESCRIPTION
### Description  
This PR increases the file upload size limit in the Storage Service to **10GB** to allow larger file uploads.  

### Changes  
- Updated `application.properties` in `storage-service` to set:  
  - `spring.servlet.multipart.max-file-size=10GB`  
  - `spring.servlet.multipart.max-request-size=10GB`  
- Updated `.gitignore` to include additional IDE and build-related files.  

### Issue Reference  
Closes #430  

### Testing  
- Verified that file uploads up to 10GB are processed without errors.  
- Ensured that smaller file uploads continue to function correctly.  
- Checked that the changes do not impact other microservices.  

### Impact  
- Enables users to upload larger files without hitting the previous limit.  
- No expected regressions, as the limits are now configurable.  
