### PR TITLE
GH-0: [feat] Creat Endpoints For Posts in Events

### DIFF
--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/config/kafka/KafkaProducerConfig.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/config/kafka/KafkaProducerConfig.java
@@ -1,26 +1,18 @@
 package app.sportahub.eventservice.config.kafka;
 
-import app.sportahub.kafkevents.JoinedSportEventEvent.JoinedEventsByUserEvent;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafka;
-import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
-import org.springframework.kafka.listener.ContainerProperties;
-import org.springframework.kafka.listener.KafkaMessageListenerContainer;
-import org.springframework.kafka.requestreply.ReplyingKafkaTemplate;
 import org.springframework.kafka.support.serializer.JsonSerializer;
-import org.springframework.kafka.transaction.KafkaTransactionManager;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
 
 @EnableKafka
 @Configuration
@@ -38,6 +30,9 @@ public class KafkaProducerConfig {
         return new DefaultKafkaProducerFactory<>(configProps);
     }
 
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
     @Bean
     public KafkaTemplate<String, Object> kafkaTemplate(ProducerFactory<String, Object> producerFactory) {
         return new KafkaTemplate<>(producerFactory);

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/controller/social/PostController.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/controller/social/PostController.java
@@ -6,6 +6,7 @@ import app.sportahub.eventservice.dto.response.ReactionResponse;
 import app.sportahub.eventservice.dto.response.social.CommentResponse;
 import app.sportahub.eventservice.dto.response.social.PostResponse;
 import app.sportahub.eventservice.model.event.reactor.ReactionType;
+import app.sportahub.eventservice.service.event.EventService;
 import app.sportahub.eventservice.service.social.PostService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -28,6 +29,7 @@ import org.springframework.web.bind.annotation.*;
 public class PostController {
 
     private final PostService postService;
+    private final EventService eventService;
 
     @PostMapping
     @PreAuthorize("@eventService.isParticipant(#eventId, authentication.name) || hasRole('ROLE_ADMIN')")
@@ -75,7 +77,6 @@ public class PostController {
     }
 
     @GetMapping("/{postId}/")
-    @PreAuthorize("@eventService.isParticipant(#eventId, authentication.name) || hasRole('ROLE_ADMIN')")
     @Operation(
             summary = "Get post in a specific event",
             description = "Get post by providing eventId and postId.",
@@ -97,7 +98,7 @@ public class PostController {
     }
 
     @DeleteMapping("/{postId}/")
-    @PreAuthorize("@eventService.isParticipant(#eventId, authentication.name) || hasRole('ROLE_ADMIN')")
+    @PreAuthorize("@postService.isPostCreator(#postId, authentication.name) || hasRole('ROLE_ADMIN')")
     @Operation(
             summary = "Deletes post in an event",
             description = "Deletes post in an event by providing eventId and postId.",
@@ -107,7 +108,7 @@ public class PostController {
             }
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Attachment added successfully", content = @Content),
+            @ApiResponse(responseCode = "200", description = "Post deleted successfully", content = @Content),
             @ApiResponse(responseCode = "403", description = "Forbidden – User is not authorized"),
             @ApiResponse(responseCode = "404", description = "Post not found")
     })
@@ -119,7 +120,6 @@ public class PostController {
     }
 
     @PostMapping("/{postId}/comment")
-    @PreAuthorize("@eventService.isParticipant(#eventId, authentication.name) || hasRole('ROLE_ADMIN')")
     @Operation(
             summary = "Creates comment in a post",
             description = "Adds comment to post by providing eventId, postId, userId, and content."
@@ -133,7 +133,10 @@ public class PostController {
     }
 
     @DeleteMapping("/{postId}/comment")
-    @PreAuthorize("@eventService.isParticipant(#eventId, authentication.name) || hasRole('ROLE_ADMIN')")
+    @PreAuthorize("@postService.isCommentCreator(#eventId, authentication.name) ||" +
+            " @postService.isPostCreator(#postId, authentication.name) ||" +
+            " @eventService.isCreator(#eventId, authentication.name) ||" +
+            " hasRole('ROLE_ADMIN')")
     @Operation(
             summary = "Deletes comment in a post",
             description = "Deletes comment in a post by providing eventId, postId, and commentId.",
@@ -144,7 +147,7 @@ public class PostController {
             }
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Attachment added successfully", content = @Content),
+            @ApiResponse(responseCode = "200", description = "Comment deleted successfully", content = @Content),
             @ApiResponse(responseCode = "403", description = "Forbidden – User is not authorized"),
             @ApiResponse(responseCode = "404", description = "Post not found")
     })

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/controller/social/PostController.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/controller/social/PostController.java
@@ -2,8 +2,10 @@ package app.sportahub.eventservice.controller.social;
 
 import app.sportahub.eventservice.dto.request.social.CommentRequest;
 import app.sportahub.eventservice.dto.request.social.PostRequest;
+import app.sportahub.eventservice.dto.response.ReactionResponse;
 import app.sportahub.eventservice.dto.response.social.CommentResponse;
 import app.sportahub.eventservice.dto.response.social.PostResponse;
+import app.sportahub.eventservice.model.event.reactor.ReactionType;
 import app.sportahub.eventservice.service.social.PostService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -152,5 +154,14 @@ public class PostController {
             @RequestParam String commentId
             ) {
         return postService.deleteComment(eventId, postId, commentId);
+    }
+
+    @PostMapping("/{postId}/reaction")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "React to a post", description = "Enables a user to react to a post given the eventId and postId.")
+    public ReactionResponse reactToPost(@PathVariable String eventId,
+                                         @PathVariable String postId,
+                                         @RequestParam ReactionType reaction) {
+        return postService.reactToPost(eventId, postId, reaction);
     }
 }

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/dto/request/social/CommentRequest.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/dto/request/social/CommentRequest.java
@@ -3,11 +3,13 @@ package app.sportahub.eventservice.dto.request.social;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.validation.constraints.NotBlank;
 
+import java.time.LocalDateTime;
+
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record CommentRequest(
         @NotBlank(message = "Comment content must be provided")
         String content,
 
         @NotBlank(message = "Valid id of the user who created the comment must be provided")
-        String createdBy) {
+        String createdBy){
 }

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/dto/response/social/CommentResponse.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/dto/response/social/CommentResponse.java
@@ -1,0 +1,11 @@
+package app.sportahub.eventservice.dto.response.social;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record CommentResponse(
+        String eventId,
+        String postId,
+        String content,
+        String createdBy) {
+}

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/dto/response/social/CommentResponse.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/dto/response/social/CommentResponse.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record CommentResponse(
         String eventId,
+        String id,
         String postId,
         String content,
         String createdBy) {

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/dto/response/social/PostResponse.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/dto/response/social/PostResponse.java
@@ -7,6 +7,7 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record PostResponse(
         String eventId,
+        String id,
         String content,
         String createdBy,
         List<String> attachments,

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/dto/response/social/PostResponse.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/dto/response/social/PostResponse.java
@@ -1,0 +1,15 @@
+package app.sportahub.eventservice.dto.response.social;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record PostResponse(
+        String eventId,
+        String content,
+        String createdBy,
+        List<String> attachments,
+        List<CommentResponse> comments
+) {
+}

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/dto/response/social/PostResponse.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/dto/response/social/PostResponse.java
@@ -1,5 +1,6 @@
 package app.sportahub.eventservice.dto.response.social;
 
+import app.sportahub.eventservice.model.event.reactor.Reaction;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import java.util.List;
@@ -11,6 +12,6 @@ public record PostResponse(
         String content,
         String createdBy,
         List<String> attachments,
-        List<CommentResponse> comments
-) {
+        List<CommentResponse> comments,
+        List<Reaction> reactions) {
 }

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/exception/event/CommentDoesNotExistException.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/exception/event/CommentDoesNotExistException.java
@@ -1,0 +1,15 @@
+package app.sportahub.eventservice.exception.event;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+@ResponseStatus(code = HttpStatus.NOT_FOUND, reason = "Post does not exist.")
+public class CommentDoesNotExistException extends ResponseStatusException {
+
+    public CommentDoesNotExistException(String id, String postId, String eventId) {
+        super(HttpStatus.NOT_FOUND, "Comment with id: " + id +
+                " does not exist in post with id: " + postId +
+                " in event with id: " + eventId);
+    }
+}

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/exception/event/CommentDoesNotExistException.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/exception/event/CommentDoesNotExistException.java
@@ -7,9 +7,7 @@ import org.springframework.web.server.ResponseStatusException;
 @ResponseStatus(code = HttpStatus.NOT_FOUND, reason = "Post does not exist.")
 public class CommentDoesNotExistException extends ResponseStatusException {
 
-    public CommentDoesNotExistException(String id, String postId, String eventId) {
-        super(HttpStatus.NOT_FOUND, "Comment with id: " + id +
-                " does not exist in post with id: " + postId +
-                " in event with id: " + eventId);
+    public CommentDoesNotExistException(String id) {
+        super(HttpStatus.NOT_FOUND, "Comment with id: " + id + " does not exist ");
     }
 }

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/exception/event/PostDoesNotExistException.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/exception/event/PostDoesNotExistException.java
@@ -1,0 +1,13 @@
+package app.sportahub.eventservice.exception.event;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+@ResponseStatus(code = HttpStatus.NOT_FOUND, reason = "Post does not exist.")
+public class PostDoesNotExistException extends ResponseStatusException {
+
+    public PostDoesNotExistException(String id, String eventId) {
+        super(HttpStatus.NOT_FOUND, "Post with id: " + id + " does not exist in event with id: " + eventId);
+    }
+}

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/exception/event/PostDoesNotExistException.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/exception/event/PostDoesNotExistException.java
@@ -7,7 +7,7 @@ import org.springframework.web.server.ResponseStatusException;
 @ResponseStatus(code = HttpStatus.NOT_FOUND, reason = "Post does not exist.")
 public class PostDoesNotExistException extends ResponseStatusException {
 
-    public PostDoesNotExistException(String id, String eventId) {
-        super(HttpStatus.NOT_FOUND, "Post with id: " + id + " does not exist in event with id: " + eventId);
+    public PostDoesNotExistException(String id) {
+        super(HttpStatus.NOT_FOUND, "Post with id: " + id + " does not exist");
     }
 }

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/exception/event/ReactionAlreadySubmittedException.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/exception/event/ReactionAlreadySubmittedException.java
@@ -6,7 +6,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 @ResponseStatus(code = HttpStatus.NOT_ACCEPTABLE, reason = "Event is closed for registration.")
 public class ReactionAlreadySubmittedException extends ResponseStatusException {
-    public ReactionAlreadySubmittedException(String eventId, String userId) {
-        super(HttpStatus.NOT_ACCEPTABLE, "This reaction is already submitted to event with id: " + eventId + " by user with id: " + userId);
+    public ReactionAlreadySubmittedException(String entityType, String eventId, String userId) {
+        super(HttpStatus.NOT_ACCEPTABLE, "This reaction is already submitted to " + entityType + " with id: " + eventId + " by user with id: " + userId);
     }
 }

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/mapper/social/CommentMapper.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/mapper/social/CommentMapper.java
@@ -1,6 +1,7 @@
 package app.sportahub.eventservice.mapper.social;
 
 import app.sportahub.eventservice.dto.request.social.CommentRequest;
+import app.sportahub.eventservice.dto.response.social.CommentResponse;
 import app.sportahub.eventservice.model.social.Comment;
 import org.mapstruct.Builder;
 import org.mapstruct.Mapper;
@@ -13,4 +14,6 @@ public interface CommentMapper {
     @Mapping(target = "creationDate", ignore = true)
     @Mapping(target = "updatedAt", ignore = true)
     Comment commentRequestToComment(CommentRequest commentRequest);
+
+    CommentResponse commentToCommentResponse(Comment comment, String eventId, String postId);
 }

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/mapper/social/PostMapper.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/mapper/social/PostMapper.java
@@ -1,6 +1,7 @@
 package app.sportahub.eventservice.mapper.social;
 
 import app.sportahub.eventservice.dto.request.social.PostRequest;
+import app.sportahub.eventservice.dto.response.social.PostResponse;
 import app.sportahub.eventservice.model.social.Post;
 import org.mapstruct.Builder;
 import org.mapstruct.Mapper;
@@ -13,4 +14,6 @@ public interface PostMapper {
     @Mapping(target = "creationDate", ignore = true)
     @Mapping(target = "updatedAt", ignore = true)
     Post postRequestToPost(PostRequest postRequest);
+
+    PostResponse postToPostResponse(Post post);
 }

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/model/social/Post.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/model/social/Post.java
@@ -1,12 +1,14 @@
 package app.sportahub.eventservice.model.social;
 
 import app.sportahub.eventservice.model.BaseEntity;
+import app.sportahub.eventservice.model.event.reactor.Reaction;
 import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.springframework.data.mongodb.core.mapping.DBRef;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -34,4 +36,7 @@ public class Post extends BaseEntity {
     @DBRef(lazy = true)
     @Builder.Default
     private List<Comment> comments = Collections.emptyList();
+
+    @Builder.Default
+    private List<Reaction> reactions = new ArrayList<>();
 }

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/repository/social/CommentRepository.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/repository/social/CommentRepository.java
@@ -1,0 +1,7 @@
+package app.sportahub.eventservice.repository.social;
+
+import app.sportahub.eventservice.model.social.Comment;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface CommentRepository extends MongoRepository<Comment, String> {
+}

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/service/event/EventServiceImpl.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/service/event/EventServiceImpl.java
@@ -611,7 +611,7 @@ public class EventServiceImpl implements EventService {
                         .build();
                 event.getReactions().remove(reactorToEvent);
             } else {
-               throw new ReactionAlreadySubmittedException(eventId, userId);
+               throw new ReactionAlreadySubmittedException("event", eventId, userId);
             }
         } else {
             if(newReaction == ReactionType.LIKE) {
@@ -621,7 +621,7 @@ public class EventServiceImpl implements EventService {
                         .build();
                 event.getReactions().add(reaction);
             } else{
-                throw new ReactionAlreadySubmittedException(eventId, userId);
+                throw new ReactionAlreadySubmittedException("event", eventId, userId);
             }
         }
 

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/service/event/EventServiceImpl.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/service/event/EventServiceImpl.java
@@ -608,6 +608,7 @@ public class EventServiceImpl implements EventService {
                 reaction = Reaction.builder()
                         .withUserId(userId)
                         .withReactionType(ReactionType.NO_REACTION)
+                        .withReactionDate(LocalDateTime.now())
                         .build();
                 event.getReactions().remove(reactorToEvent);
             } else {
@@ -618,6 +619,7 @@ public class EventServiceImpl implements EventService {
                 reaction = Reaction.builder()
                         .withUserId(userId)
                         .withReactionType(ReactionType.LIKE)
+                        .withReactionDate(LocalDateTime.now())
                         .build();
                 event.getReactions().add(reaction);
             } else{

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/service/social/PostService.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/service/social/PostService.java
@@ -2,8 +2,10 @@ package app.sportahub.eventservice.service.social;
 
 import app.sportahub.eventservice.dto.request.social.CommentRequest;
 import app.sportahub.eventservice.dto.request.social.PostRequest;
+import app.sportahub.eventservice.dto.response.ReactionResponse;
 import app.sportahub.eventservice.dto.response.social.CommentResponse;
 import app.sportahub.eventservice.dto.response.social.PostResponse;
+import app.sportahub.eventservice.model.event.reactor.ReactionType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -19,4 +21,6 @@ public interface PostService {
     CommentResponse deleteComment(String eventId, String postId, String commentId);
 
     PostResponse deletePost(String eventId, String postId);
+
+    ReactionResponse reactToPost(String eventId, String postId, ReactionType reactionType);
 }

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/service/social/PostService.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/service/social/PostService.java
@@ -23,4 +23,8 @@ public interface PostService {
     PostResponse deletePost(String eventId, String postId);
 
     ReactionResponse reactToPost(String eventId, String postId, ReactionType reactionType);
+
+    boolean isPostCreator(String eventId, String userId);
+
+    boolean isCommentCreator(String eventId, String userId);
 }

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/service/social/PostService.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/service/social/PostService.java
@@ -1,12 +1,22 @@
 package app.sportahub.eventservice.service.social;
 
+import app.sportahub.eventservice.dto.request.social.CommentRequest;
 import app.sportahub.eventservice.dto.request.social.PostRequest;
-import app.sportahub.eventservice.model.social.Post;
+import app.sportahub.eventservice.dto.response.social.CommentResponse;
+import app.sportahub.eventservice.dto.response.social.PostResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface PostService {
-    Post createPost(String eventId, PostRequest postRequest);
+    PostResponse createPost(String eventId, PostRequest postRequest);
 
-    Page<Post> getAllPostsOrderedByCreationDateInDesc(String eventId, Pageable pageable);
+    Page<PostResponse> getAllPostsOrderedByCreationDateInDesc(String eventId, Pageable pageable);
+
+    PostResponse getPost(String eventId, String postId);
+
+    CommentResponse createComment(String eventId, String postId, CommentRequest commentRequest);
+
+    CommentResponse deleteComment(String eventId, String postId, String commentId);
+
+    PostResponse deletePost(String eventId, String postId);
 }

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/service/social/PostServiceImpl.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/service/social/PostServiceImpl.java
@@ -1,11 +1,19 @@
 package app.sportahub.eventservice.service.social;
 
+import app.sportahub.eventservice.dto.request.social.CommentRequest;
 import app.sportahub.eventservice.dto.request.social.PostRequest;
+import app.sportahub.eventservice.dto.response.social.CommentResponse;
+import app.sportahub.eventservice.dto.response.social.PostResponse;
+import app.sportahub.eventservice.exception.event.CommentDoesNotExistException;
 import app.sportahub.eventservice.exception.event.EventDoesNotExistException;
+import app.sportahub.eventservice.exception.event.PostDoesNotExistException;
+import app.sportahub.eventservice.mapper.social.CommentMapper;
 import app.sportahub.eventservice.mapper.social.PostMapper;
 import app.sportahub.eventservice.model.event.Event;
+import app.sportahub.eventservice.model.social.Comment;
 import app.sportahub.eventservice.model.social.Post;
 import app.sportahub.eventservice.repository.event.EventRepository;
+import app.sportahub.eventservice.repository.social.CommentRepository;
 import app.sportahub.eventservice.repository.social.PostRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,6 +25,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service("postService")
@@ -25,7 +36,8 @@ public class PostServiceImpl implements PostService {
 
     private final PostRepository postRepository;
     private final EventRepository eventRepository;
-
+    private final CommentMapper commentMapper;
+    private final CommentRepository commentRepository;
     private final PostMapper postMapper;
 
     /**
@@ -44,7 +56,7 @@ public class PostServiceImpl implements PostService {
      */
     @Transactional
     @Override
-    public Post createPost(String eventId, PostRequest postRequest) {
+    public PostResponse createPost(String eventId, PostRequest postRequest) {
         Event event = eventRepository.findEventById(eventId).orElseThrow(() -> new EventDoesNotExistException(eventId));
 
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
@@ -62,7 +74,8 @@ public class PostServiceImpl implements PostService {
         postRepository.save(post);
         eventRepository.save(event);
         log.info("Creating a new post for eventId: {} with the provided details: {}", eventId, postRequest);
-        return post;
+
+        return postMapper.postToPostResponse(post);
     }
 
     /**
@@ -79,16 +92,163 @@ public class PostServiceImpl implements PostService {
      * @throws EventDoesNotExistException if no event is found with the given {@code eventId}.
      */
     @Override
-    public Page<Post> getAllPostsOrderedByCreationDateInDesc(String eventId, Pageable pageable) {
-        eventRepository.findEventById(eventId).orElseThrow(() -> new EventDoesNotExistException(eventId));
+    public Page<PostResponse> getAllPostsOrderedByCreationDateInDesc(String eventId, Pageable pageable) {
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new EventDoesNotExistException(eventId));
 
-        Pageable sortedPageable = PageRequest.of(
-                pageable.getPageNumber(),
-                pageable.getPageSize(),
-                Sort.by(Sort.Direction.DESC, "creationDate")
+        List<PostResponse> sortedPosts = event.getPosts().stream()
+                .sorted(Comparator.comparing(Post::getCreationDate).reversed())
+                .map(postMapper::postToPostResponse)
+                .collect(Collectors.toList());
+
+        int start = (int) pageable.getOffset();
+        int end = Math.min((start + pageable.getPageSize()), sortedPosts.size());
+
+        log.info("Retrieved all posts in event with Id: {}", eventId);
+
+        return new PageImpl<>(
+                sortedPosts.subList(start, end),
+                pageable,
+                sortedPosts.size()
         );
+    }
 
-        Page<Post> posts = postRepository.findByEventId(eventId, sortedPageable);
-        return new PageImpl<>(posts.getContent(), posts.getPageable(), posts.getTotalElements());
+    /**
+     * Retrieves a specific post from an event.
+     *
+     * @param eventId the ID of the event containing the post
+     * @param postId the ID of the post to retrieve
+     * @return PostResponse containing the post data
+     * @throws EventDoesNotExistException if no event exists with the given eventId
+     * @throws PostDoesNotExistException if no post exists with the given postId in the specified event
+     */
+    @Override
+    public PostResponse getPost(String eventId, String postId){
+
+        Event event = eventRepository.findEventById(eventId).orElseThrow(() -> new EventDoesNotExistException(eventId));
+
+        Post post = event.getPosts().stream()
+                .filter(p -> p.getId().equals(postId))
+                .findFirst()
+                .orElseThrow(() -> new PostDoesNotExistException(postId, eventId));
+
+        log.info("Retrieved post with Id: {} in event with Id: {}", postId, eventId);
+        return  postMapper.postToPostResponse(post);
+    }
+
+    /**
+     * Deletes a post from an event and returns the deleted post data.
+     * This operation is transactional and will remove the post from both the event's post list
+     * and the post repository.
+     *
+     * @param eventId the ID of the event containing the post to delete
+     * @param postId the ID of the post to delete
+     * @return PostResponse containing the deleted post data
+     * @throws EventDoesNotExistException if no event exists with the given eventId
+     * @throws PostDoesNotExistException if no post exists with the given postId in the specified event
+     */
+    @Transactional
+    @Override
+    public PostResponse deletePost(String eventId, String postId){
+        Event event = eventRepository.findEventById(eventId).orElseThrow(() -> new EventDoesNotExistException(eventId));
+
+        Post postToDelete = event.getPosts().stream()
+                .filter(p -> p.getId().equals(postId))
+                .findFirst()
+                .orElseThrow(() -> new PostDoesNotExistException(postId, eventId));
+
+        event.getPosts().remove(postToDelete);
+
+        postRepository.deleteById(postToDelete.getId());
+        eventRepository.save(event);
+
+        log.info("Deleted post with Id: {} in event with Id: {}", postId, eventId);
+        return  postMapper.postToPostResponse(postToDelete);
+    }
+
+    /**
+     * Creates a new comment on a post within an event.
+     * This operation is transactional and associates the comment with the authenticated user.
+     *
+     * @param eventId the ID of the event containing the post
+     * @param postId the ID of the post to comment on
+     * @param commentRequest the request object containing comment details
+     * @return CommentResponse containing the created comment data
+     * @throws EventDoesNotExistException if no event exists with the given eventId
+     * @throws PostDoesNotExistException if no post exists with the given postId in the specified event
+     * @throws IllegalStateException if no authentication context is available
+     */
+    @Transactional
+    @Override
+    public CommentResponse createComment(String eventId, String postId, CommentRequest commentRequest){
+
+        Event event = eventRepository.findEventById(eventId).orElseThrow(() -> new EventDoesNotExistException(eventId));
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        Post post = event.getPosts().stream()
+                .filter(p -> p.getId().equals(postId))
+                .findFirst()
+                .orElseThrow(() -> new PostDoesNotExistException(postId, eventId));
+
+        String commentCreator = commentRequest.createdBy();
+        String commentContent = commentRequest.content();
+        new Comment(commentCreator, commentContent);
+        Comment comment =  commentMapper.commentRequestToComment(commentRequest)
+                .toBuilder()
+                .withCreatedBy(commentCreator)
+                .withUpdatedAt(Timestamp.valueOf(LocalDateTime.now()))
+                .withContent(commentContent)
+                .withCreatedBy(authentication.getName())
+                .build();
+
+        post.getComments().add(comment);
+
+        commentRepository.save(comment);
+        eventRepository.save(event);
+        postRepository.save(post);
+
+        log.info("Created comment to post with Id: {} in event with Id: {}", postId, eventId);
+        return commentMapper.commentToCommentResponse(comment, eventId, postId);
+    }
+
+    /**
+     * Deletes a comment from a post within an event.
+     * This operation is transactional and removes the comment from both the post's comment list
+     * and the comment repository.
+     *
+     * @param eventId the ID of the event containing the post
+     * @param postId the ID of the post containing the comment
+     * @param commentId the ID of the comment to delete
+     * @return CommentResponse containing the deleted comment data
+     * @throws EventDoesNotExistException if no event exists with the given eventId
+     * @throws PostDoesNotExistException if no post exists with the given postId in the specified event
+     * @throws CommentDoesNotExistException if no comment exists with the given commentId on the specified post
+     */
+    @Transactional
+    @Override
+    public CommentResponse deleteComment(String eventId, String postId, String commentId){
+
+        Event event = eventRepository.findEventById(eventId).orElseThrow(() -> new EventDoesNotExistException(eventId));
+
+        Post post = event.getPosts().stream()
+                .filter(p -> p.getId().equals(postId))
+                .findFirst()
+                .orElseThrow(() -> new PostDoesNotExistException(postId, eventId));
+
+        Comment commentToDelete = post.getComments().stream()
+                .filter(comment -> comment.getId().equals(commentId))
+                .findFirst()
+                .orElseThrow(() -> new CommentDoesNotExistException(commentId, postId, eventId));
+
+        post.getComments().removeIf(comment -> comment.getId().equals(commentId));
+
+        postRepository.save(post);
+        commentRepository.deleteById(commentToDelete.getId());
+        eventRepository.save(event);
+
+        log.info("Deleted comment with Id: {} in post with Id: {}in event with Id: {}", commentId, postId, eventId);
+
+        return commentMapper.commentToCommentResponse(commentToDelete, eventId, postId);
     }
 }

--- a/Microservices/event-service/src/test/java/app/sportahub/eventservice/controller/social/PostControllerTest.java
+++ b/Microservices/event-service/src/test/java/app/sportahub/eventservice/controller/social/PostControllerTest.java
@@ -2,9 +2,11 @@ package app.sportahub.eventservice.controller.social;
 
 import app.sportahub.eventservice.dto.request.social.CommentRequest;
 import app.sportahub.eventservice.dto.request.social.PostRequest;
+import app.sportahub.eventservice.dto.response.ReactionResponse;
 import app.sportahub.eventservice.dto.response.social.CommentResponse;
 import app.sportahub.eventservice.dto.response.social.PostResponse;
 import app.sportahub.eventservice.mapper.social.PostMapper;
+import app.sportahub.eventservice.model.event.reactor.ReactionType;
 import app.sportahub.eventservice.model.social.Post;
 import app.sportahub.eventservice.service.event.EventService;
 import app.sportahub.eventservice.service.social.PostService;
@@ -12,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -21,6 +24,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import java.util.List;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -46,6 +50,7 @@ public class PostControllerTest {
     @Mock
     private Post post;
 
+    private ReactionResponse reactionResponse;
     private final String eventId = "event1";
     private final String postId = "post1";
     private final String commentId = "comment1";
@@ -79,7 +84,7 @@ public class PostControllerTest {
     @Test
     @WithMockUser
     void getPost_ShouldReturnPostResponse() {
-        PostResponse expectedResponse = new PostResponse(postId, "content", null, null, null);
+        PostResponse expectedResponse = new PostResponse(postId, null, "content", null, null, null, null);
 
         when(postService.getPost(eventId, postId)).thenReturn(expectedResponse);
 
@@ -92,7 +97,7 @@ public class PostControllerTest {
     @Test
     @WithMockUser
     void deletePost_ShouldReturnPostResponse() {
-        PostResponse expectedResponse = new PostResponse(postId, "content", null, null, null);
+        PostResponse expectedResponse = new PostResponse(postId,  null,"content", null, null, null, null);
 
         when(postService.deletePost(eventId, postId)).thenReturn(expectedResponse);
 //        when(eventService.isParticipant(eventId, username)).thenReturn(true);
@@ -106,7 +111,7 @@ public class PostControllerTest {
     @Test
     @WithMockUser(roles = "ADMIN")
     void deletePost_AsAdmin_ShouldSucceed() {
-        PostResponse expectedResponse = new PostResponse(postId, "content", null, null, null);
+        PostResponse expectedResponse = new PostResponse(postId, null, "content", null, null, null, null);
 
         when(postService.deletePost(eventId, postId)).thenReturn(expectedResponse);
 
@@ -120,7 +125,7 @@ public class PostControllerTest {
     @WithMockUser
     void createComment_ShouldReturnCommentResponse() {
         CommentRequest request = new CommentRequest("Test comment", username);
-        CommentResponse expectedResponse = new CommentResponse(commentId, "Test comment", username, null);
+        CommentResponse expectedResponse = new CommentResponse(commentId, null,"Test comment", username, null);
 
         when(postService.createComment(eventId, postId, request)).thenReturn(expectedResponse);
 
@@ -133,7 +138,7 @@ public class PostControllerTest {
     @Test
     @WithMockUser
     void deleteComment_ShouldReturnCommentResponse() {
-        CommentResponse expectedResponse = new CommentResponse(commentId, "Test comment", username, null);
+        CommentResponse expectedResponse = new CommentResponse(commentId, null,"Test comment", username, null);
 
         when(postService.deleteComment(eventId, postId, commentId)).thenReturn(expectedResponse);
 
@@ -141,5 +146,16 @@ public class PostControllerTest {
 
         verify(postService).deleteComment(eventId, postId, commentId);
         assertThat(result).isEqualTo(expectedResponse);
+    }
+
+    @Test
+    public void testReactToEvent() {
+        Mockito.when(postService.reactToPost(Mockito.eq("testId"), Mockito.eq("postId"), Mockito.eq(ReactionType.LIKE)))
+                .thenReturn(reactionResponse);
+
+        ReactionResponse response = postController.reactToPost("testId", "postId", ReactionType.LIKE);
+
+        assertEquals(reactionResponse, response);
+        Mockito.verify(postService).reactToPost(Mockito.eq("testId"), Mockito.eq("postId"), Mockito.eq(ReactionType.LIKE));
     }
 }

--- a/Microservices/event-service/src/test/java/app/sportahub/eventservice/service/event/EventSearchTest.java
+++ b/Microservices/event-service/src/test/java/app/sportahub/eventservice/service/event/EventSearchTest.java
@@ -10,6 +10,7 @@ import app.sportahub.eventservice.model.event.Event;
 import app.sportahub.eventservice.model.event.Location;
 import app.sportahub.eventservice.repository.SearchingEventRepositoryImpl;
 import app.sportahub.eventservice.repository.event.EventRepository;
+import app.sportahub.eventservice.repository.social.PostRepository;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -45,6 +46,9 @@ public class EventSearchTest {
 
     @Mock
     private EventMapper eventMapper;
+
+    @Mock
+    private PostRepository postRepository;
 
     @Mock
     private MongoTemplate mongoTemplate;

--- a/Microservices/event-service/src/test/java/app/sportahub/eventservice/service/social/PostServiceImplTest.java
+++ b/Microservices/event-service/src/test/java/app/sportahub/eventservice/service/social/PostServiceImplTest.java
@@ -1,11 +1,18 @@
 package app.sportahub.eventservice.service.social;
 
+import app.sportahub.eventservice.dto.request.social.CommentRequest;
 import app.sportahub.eventservice.dto.request.social.PostRequest;
+import app.sportahub.eventservice.dto.response.social.CommentResponse;
+import app.sportahub.eventservice.dto.response.social.PostResponse;
 import app.sportahub.eventservice.exception.event.EventDoesNotExistException;
+import app.sportahub.eventservice.exception.event.PostDoesNotExistException;
+import app.sportahub.eventservice.mapper.social.CommentMapper;
 import app.sportahub.eventservice.mapper.social.PostMapper;
 import app.sportahub.eventservice.model.event.Event;
+import app.sportahub.eventservice.model.social.Comment;
 import app.sportahub.eventservice.model.social.Post;
 import app.sportahub.eventservice.repository.event.EventRepository;
+import app.sportahub.eventservice.repository.social.CommentRepository;
 import app.sportahub.eventservice.repository.social.PostRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -13,12 +20,15 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.*;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -38,6 +48,12 @@ public class PostServiceImplTest {
     private EventRepository eventRepository;
 
     @Mock
+    private CommentMapper commentMapper;
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
     private PostMapper postMapper;
 
     @InjectMocks
@@ -46,30 +62,47 @@ public class PostServiceImplTest {
     private PostRequest postRequest;
     private Post post;
     private Event event;
+    private CommentRequest commentRequest;
+    private Comment comment;
 
     @BeforeEach
     void setUp() {
         postRequest = new PostRequest("Content of the post", new ArrayList<>());
-        post = Post.builder().withEventId("1").withCreatedBy("adminUser").build();
+        post = Post.builder()
+                .withId("post1")
+                .withEventId("event1")
+                .withCreatedBy("user1")
+                .withCreationDate(Timestamp.valueOf(LocalDateTime.now()))
+                .build();
+
+        commentRequest = new CommentRequest("comment content", "user1");
+        comment = Comment.builder()
+                .withId("comment1")
+                .withContent("comment content")
+                .withCreatedBy("user1")
+                .build();
+
         event = new Event();
-        event.setPosts(new ArrayList<>());
+        event.setId("event1");
+        event.setPosts(new ArrayList<>(List.of(post)));
+        post.setComments(new ArrayList<>(List.of(comment)));
     }
 
     @Test
     void testCreatePostShouldCreateAndReturnPost() {
-        String eventId = "1";
+        String eventId = "event1";
 
         Authentication authentication = mock(Authentication.class);
         SecurityContext securityContext = mock(SecurityContext.class);
         when(securityContext.getAuthentication()).thenReturn(authentication);
-        when(authentication.getName()).thenReturn("adminUser");
+        when(authentication.getName()).thenReturn("user1");
         SecurityContextHolder.setContext(securityContext);
 
         when(eventRepository.findEventById(eventId)).thenReturn(Optional.of(event));
         when(postMapper.postRequestToPost(postRequest)).thenReturn(post);
         when(postRepository.save(any(Post.class))).thenReturn(post);
 
-        Post createdPost = postService.createPost(eventId, postRequest);
+        PostResponse createdPost = postService.createPost(eventId, postRequest);
 
         verify(eventRepository).findEventById(eventId);
         verify(postMapper).postRequestToPost(postRequest);
@@ -83,7 +116,7 @@ public class PostServiceImplTest {
         assertThat(capturedPost.getEventId()).isEqualTo(eventId);
         assertThat(capturedPost.getCreationDate()).isNotNull();
         assertThat(capturedPost.getUpdatedAt()).isNotNull();
-        assertThat(createdPost).isEqualTo(post);
+        assertThat(createdPost).isEqualTo(postMapper.postToPostResponse(post));
     }
 
     @Test
@@ -102,34 +135,139 @@ public class PostServiceImplTest {
     }
 
     @Test
-    void testGetAllPostsOrderedByCreationDateInDescShouldReturnSortedPosts() {
-        String eventId = "1";
-        Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "creationDate"));
-        Page<Post> mockPage = new PageImpl<>(List.of(post));
+    void createPost_WhenEventNotFound_ShouldThrowException() {
+        String eventId = "nonexistent";
 
-        when(eventRepository.findEventById(eventId)).thenReturn(Optional.of(event));
-        when(postRepository.findByEventId(eventId, pageable)).thenReturn(mockPage);
+        when(eventRepository.findEventById(eventId)).thenReturn(Optional.empty());
 
-        Page<Post> resultPage = postService.getAllPostsOrderedByCreationDateInDesc(eventId, pageable);
-
-        verify(eventRepository).findEventById(eventId);
-        verify(postRepository).findByEventId(eventId, pageable);
-
-        assertThat(resultPage).isEqualTo(mockPage);
+        assertThatThrownBy(() -> postService.createPost(eventId, postRequest))
+                .isInstanceOf(EventDoesNotExistException.class)
+                .hasMessageContaining(eventId);
     }
 
     @Test
-    void testGetAllPostsOrderedByCreationDateInDescWhenEventDoesNotExistShouldThrowException() {
-        String eventId = "1";
-        Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "creationDate"));
+    void getAllPostsOrderedByCreationDateInDesc_ShouldReturnSortedPosts() {
+        String eventId = "event1";
+        Pageable pageable = PageRequest.of(0, 10);
 
-        when(eventRepository.findEventById(eventId)).thenReturn(Optional.empty());
+        when(eventRepository.findById(eventId)).thenReturn(Optional.of(event));
+
+        Page<PostResponse> result = postService.getAllPostsOrderedByCreationDateInDesc(eventId, pageable);
+
+        verify(eventRepository).findById(eventId);
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().getFirst()).isEqualTo(postMapper.postToPostResponse(post));
+    }
+
+    @Test
+    void getAllPostsOrderedByCreationDateInDesc_WhenEventNotFound_ShouldThrowException() {
+        String eventId = "nonexistent";
+        Pageable pageable = PageRequest.of(0, 10);
+
+        when(eventRepository.findById(eventId)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> postService.getAllPostsOrderedByCreationDateInDesc(eventId, pageable))
                 .isInstanceOf(EventDoesNotExistException.class)
                 .hasMessageContaining(eventId);
+    }
+
+    @Test
+    void getPost_ShouldReturnPost() {
+        String eventId = "event1";
+        String postId = "post1";
+        PostResponse expectedResponse = new PostResponse("post1", "content", null, null, null);
+
+        when(eventRepository.findEventById(eventId)).thenReturn(Optional.of(event));
+        when(postMapper.postToPostResponse(post)).thenReturn(expectedResponse);
+
+        PostResponse result = postService.getPost(eventId, postId);
 
         verify(eventRepository).findEventById(eventId);
-        verify(postRepository, never()).findByEventId(anyString(), any(Pageable.class));
+        verify(postMapper).postToPostResponse(post);
+        assertThat(result).isEqualTo(expectedResponse);
+    }
+
+    @Test
+    void getPost_WhenPostNotFound_ShouldThrowException() {
+        String eventId = "event1";
+        String postId = "nonexistent";
+
+        when(eventRepository.findEventById(eventId)).thenReturn(Optional.of(event));
+
+        assertThatThrownBy(() -> postService.getPost(eventId, postId))
+                .isInstanceOf(PostDoesNotExistException.class)
+                .hasMessageContaining(postId);
+    }
+
+    @Test
+    void deletePost_ShouldRemovePost() {
+        String eventId = "event1";
+        String postId = "post1";
+        PostResponse expectedResponse = new PostResponse("post1", "content", null, null, null);
+
+        when(eventRepository.findEventById(eventId)).thenReturn(Optional.of(event));
+        when(postMapper.postToPostResponse(post)).thenReturn(expectedResponse);
+
+        PostResponse result = postService.deletePost(eventId, postId);
+
+        verify(eventRepository).findEventById(eventId);
+        verify(postRepository).deleteById(postId);
+        verify(eventRepository).save(event);
+        verify(postMapper).postToPostResponse(post);
+
+        assertThat(result).isEqualTo(expectedResponse);
+        assertThat(event.getPosts()).doesNotContain(post);
+    }
+
+    @Test
+    void createComment_ShouldAddCommentToPost() {
+        String eventId = "event1";
+        String postId = "post1";
+        CommentResponse expectedResponse = new CommentResponse("comment1", "content", "user1", null);
+
+        Authentication auth = mock(Authentication.class);
+        SecurityContext securityContext = mock(SecurityContext.class);
+        when(securityContext.getAuthentication()).thenReturn(auth);
+        when(auth.getName()).thenReturn("user1");
+        SecurityContextHolder.setContext(securityContext);
+
+        when(eventRepository.findEventById(eventId)).thenReturn(Optional.of(event));
+        when(commentMapper.commentRequestToComment(commentRequest)).thenReturn(comment);
+        when(commentMapper.commentToCommentResponse(comment, eventId, postId))
+                .thenReturn(expectedResponse);
+        when(commentRepository.save(comment)).thenReturn(comment);
+
+        CommentResponse result = postService.createComment(eventId, postId, commentRequest);
+
+        verify(eventRepository).findEventById(eventId);
+        verify(commentMapper).commentRequestToComment(commentRequest);
+        verify(commentRepository).save(comment);
+        verify(postRepository).save(post);
+        verify(eventRepository).save(event);
+
+        assertThat(result).isEqualTo(expectedResponse);
+        assertThat(post.getComments()).contains(comment);
+    }
+
+    @Test
+    void deleteComment_ShouldRemoveComment() {
+        String eventId = "event1";
+        String postId = "post1";
+        String commentId = "comment1";
+        CommentResponse expectedResponse = new CommentResponse("comment1", "content", "user1", null);
+
+        when(eventRepository.findEventById(eventId)).thenReturn(Optional.of(event));
+        when(commentMapper.commentToCommentResponse(comment, eventId, postId))
+                .thenReturn(expectedResponse);
+
+        CommentResponse result = postService.deleteComment(eventId, postId, commentId);
+
+        verify(eventRepository).findEventById(eventId);
+        verify(commentRepository).deleteById(commentId);
+        verify(postRepository).save(post);
+        verify(eventRepository).save(event);
+
+        assertThat(result).isEqualTo(expectedResponse);
+        assertThat(post.getComments()).doesNotContain(comment);
     }
 }


### PR DESCRIPTION
## Description

This PR aims at introducing the following endpoints to interact with event posts and comments:

- GET `event/{eventId}/social/post/{postID}` to retrieve a specific Post with its comments.
- DELETE `event/{eventId}/social/post/{postID}` to delete the Post associated with the postId and eventId provided.
- POST `event/{eventId}/social/post/{postID}/comment` to create a Comment under the specified Post.
- DELETE `event/{eventId}/social/post/{postID}/comment/{commentId}` to delete a Comment in the Post specified.
- POST `event/{eventId}/social/post/{postID}/reaction` to allow users to react to a Post in an Event.

## Testing

Tested controller and service layer logic to ensure desired behavior is acheived.