### PR TITLE
GH-0: [refactor] Added distance filter to event search endpoint.

### DIFF
--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/controller/event/EventController.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/controller/event/EventController.java
@@ -158,6 +158,8 @@ public class EventController {
     @Operation(summary = "Search for events",
             description = "Allows the search of events based on various filters like name, sport type, event type, location, date, and more.")
     public Page<EventResponse> searchEvents(
+            @RequestParam(required = true) double longitude,
+            @RequestParam(required = true) double latitude,
             @RequestParam(required = false) String eventName,
             @RequestParam(required = false) String eventType,
             @RequestParam(required = false) String sportType,
@@ -177,7 +179,9 @@ public class EventController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
         Pageable pageable = PageRequest.of(page, size);
-        return eventService.searchEvents(eventName, eventType, sportType, locationName, city, province, country, postalCode, date, startTime, endTime, duration, maxParticipants, createdBy, isPrivate, requiredSkillLevel, pageable);
+        return eventService.searchEvents(eventName, eventType, sportType, locationName, city, province, country,
+                postalCode, date, startTime, endTime, duration, maxParticipants, createdBy, isPrivate,
+                requiredSkillLevel, pageable, longitude, latitude);
     }
 
     @PostMapping("/{id}/reaction")

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/exception/event/InvalidEventCoordinatesReceivedException.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/exception/event/InvalidEventCoordinatesReceivedException.java
@@ -1,0 +1,14 @@
+package app.sportahub.eventservice.exception.event;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+@ResponseStatus(code = HttpStatus.BAD_REQUEST, reason = "Coordinates are invalid for the Event Model.")
+public class InvalidEventCoordinatesReceivedException extends ResponseStatusException {
+
+    public InvalidEventCoordinatesReceivedException() {
+
+        super(HttpStatus.BAD_REQUEST, "The given coordinates are null or not in the expected GeoJsonPoint format.");
+    }
+}

--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/service/event/EventService.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/service/event/EventService.java
@@ -64,7 +64,9 @@ public interface EventService {
                                      String createdBy,
                                      Boolean isPrivate,
                                      List<SkillLevelEnum> requiredSkillLevel,
-                                     Pageable pageable);
+                                     Pageable pageable,
+                                     double longitude,
+                                     double latitude);
 
 
     ReactionResponse reactToEvent(String id, ReactionType reaction);

--- a/Microservices/event-service/src/test/java/app/sportahub/eventservice/controller/event/EventControllerTest.java
+++ b/Microservices/event-service/src/test/java/app/sportahub/eventservice/controller/event/EventControllerTest.java
@@ -305,11 +305,14 @@ public class EventControllerTest {
         // Mock the service method
         when(eventService.searchEvents(
                 anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), anyString(),
-                anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), any(), any(), any()
+                anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), any(), any(), any(), any(Double.class),
+                any(Double.class)
         )).thenReturn(mockPage);
 
         // Act
         Page<EventResponse> result = eventController.searchEvents(
+                -74,
+                40,
                 "Soccer Match", // eventName
                 "Friendly", // eventType
                 "Soccer", // sportType
@@ -354,8 +357,10 @@ public class EventControllerTest {
 
         // Verify interactions
         verify(eventService).searchEvents(
-                "Soccer Match", "Friendly", "Soccer", "Central Park", "New York", "NY", "USA", "10001",
-                "2023-10-15", "14:00", "16:00", "120", "20", "user123", false, List.of(SkillLevelEnum.INTERMEDIATE), pageable
+                "Soccer Match", "Friendly", "Soccer", "Central Park",
+                "New York", "NY", "USA", "10001", "2023-10-15",
+                "14:00", "16:00", "120", "20", "user123",
+                false, List.of(SkillLevelEnum.INTERMEDIATE), pageable, -74, 40
         );
     }
 

--- a/Microservices/event-service/src/test/java/app/sportahub/eventservice/service/event/EventServiceTest.java
+++ b/Microservices/event-service/src/test/java/app/sportahub/eventservice/service/event/EventServiceTest.java
@@ -2,6 +2,7 @@ package app.sportahub.eventservice.service.event;
 
 import app.sportahub.eventservice.dto.request.event.EventCancellationRequest;
 import app.sportahub.eventservice.dto.request.event.EventRequest;
+import app.sportahub.eventservice.dto.request.event.LocationRequest;
 import app.sportahub.eventservice.dto.response.EventResponse;
 import app.sportahub.eventservice.dto.response.ParticipantResponse;
 import app.sportahub.eventservice.dto.response.ReactionResponse;
@@ -11,6 +12,7 @@ import app.sportahub.eventservice.enums.SortDirection;
 import app.sportahub.eventservice.exception.event.*;
 import app.sportahub.eventservice.mapper.event.EventMapper;
 import app.sportahub.eventservice.model.event.Event;
+import app.sportahub.eventservice.model.event.Location;
 import app.sportahub.eventservice.model.event.participant.Participant;
 import app.sportahub.eventservice.model.event.participant.ParticipantAttendStatus;
 import app.sportahub.eventservice.repository.event.EventRepository;
@@ -68,6 +70,24 @@ class EventServiceTest {
     @BeforeEach
     void setUp() {
         cancelRequest = new EventCancellationRequest("Weather conditions");
+
+        LocationRequest locationRequest = new LocationRequest(
+                "Parc Lafontaine",
+                "3819",
+                "Av. Calixa-Lavallée",
+                "Montréal",
+                "Québec",
+                "Canada",
+                "H2H 1P4",
+                null,
+                null,
+                new GeoJsonPoint(45.52757745329691, -73.57033414232836)
+        );
+
+        Location location = new Location(locationRequest.name(), locationRequest.streetNumber(),
+                locationRequest.streetName(), locationRequest.city(), locationRequest.province(),
+                locationRequest.country(), locationRequest.postalCode(), locationRequest.addressLine2(),
+                locationRequest.phoneNumber(), locationRequest.coordinates());
         participant = Participant.builder()
                 .withUserId("user123")
                 .withAttendStatus(ParticipantAttendStatus.JOINED)
@@ -77,6 +97,7 @@ class EventServiceTest {
         event = Event.builder()
                 .withId("1")
                 .withEventName("Basketball Game")
+                .withLocation(location)
                 .withMaxParticipants(10)
                 .withParticipants(Collections.singletonList(participant))
                 .withCreatedBy("creatorId")
@@ -114,7 +135,7 @@ class EventServiceTest {
                 "Basketball Practice",
                 "Public",
                 "Basketball",
-                null,
+                locationRequest,
                 LocalDateTime.now().toLocalDate(),
                 LocalDateTime.now().toLocalTime(),
                 LocalDateTime.now().toLocalTime().plusHours(2),


### PR DESCRIPTION
Added distance filter that mimics the logic of the GET relevant-events endpoint; start at a radius of 25km and double if no events are found.

Also added a check to the create event method that enforces proper GeoJsonPoint coordinates before creating the event, as this was causing issues with returning search results.
 
As a safety, I also added a check that will ignore all events with invalid GeoJsonPoints from search results, preventing the search event method from throwing an error if it encounters such events.

Fixed all tests that broke due to these changes.
