### PR TITLE
[fix] Update SecurityConfig to allow access to actuator endpoints

### DIFF
--- a/Microservices/notification-service/src/main/java/app/sportahub/notificationservice/config/auth/SecurityConfig.java
+++ b/Microservices/notification-service/src/main/java/app/sportahub/notificationservice/config/auth/SecurityConfig.java
@@ -33,7 +33,8 @@ public class SecurityConfig {
                                 "/api-docs",
                                 "/api-docs/**",
                                 "/swagger-ui/**",
-                                "/webjars/**")
+                                "/webjars/**",
+                                "/actuator/**")
                         .permitAll()
                         .anyRequest().authenticated())
                 .csrf(AbstractHttpConfigurer::disable)


### PR DESCRIPTION
# Description

Notification Service is failing because it is not allowing health checks.