### PR TITLE
[fix] Remove Redundant KafkaTemplate Bean Method

### DIFF
--- a/Microservices/event-service/src/main/java/app/sportahub/eventservice/config/kafka/KafkaProducerConfig.java
+++ b/Microservices/event-service/src/main/java/app/sportahub/eventservice/config/kafka/KafkaProducerConfig.java
@@ -31,11 +31,6 @@ public class KafkaProducerConfig {
     }
 
     @Bean
-    public KafkaTemplate<String, Object> kafkaTemplate() {
-        return new KafkaTemplate<>(producerFactory());
-    }
-
-    @Bean
     public KafkaTemplate<String, Object> kafkaTemplate(ProducerFactory<String, Object> producerFactory) {
         return new KafkaTemplate<>(producerFactory);
     }


### PR DESCRIPTION
# Description
This PR removes a redundant `kafkaTemplate` bean method in `KafkaProducerConfig`. The method was unnecessary as there was already a properly defined `KafkaTemplate` bean that uses `ProducerFactory`. It causes the app to crash. 